### PR TITLE
missing env file for DelphesAnalysis

### DIFF
--- a/DelphesEnv.sh
+++ b/DelphesEnv.sh
@@ -1,0 +1,3 @@
+export PYTHONPATH=`pwd`/python:$PYTHONPATH
+export LD_LIBRARY_PATH=`pwd`:$LD_LIBRARY_PATH
+


### PR DESCRIPTION
This is a small file to "setup the environment".
It just sets LD_LIBRARY_PATH and PYTHONPATH.
