### PR TITLE
(just a comment) variables should be declared closer to where used

### DIFF
--- a/modules/TauTagging.cc
+++ b/modules/TauTagging.cc
@@ -60,13 +60,10 @@ TauTaggingPartonClassifier::TauTaggingPartonClassifier(const TObjArray *array) :
 Int_t TauTaggingPartonClassifier::GetCategory(TObject *object)
 {
   Candidate *tau = static_cast<Candidate *>(object);
-  Candidate *daughter1 = 0;
-  Candidate *daughter2 = 0;
   
   const TLorentzVector &momentum = tau->Momentum;
-  Int_t pdgCode, i, j;
 
-  pdgCode = TMath::Abs(tau->PID);
+  Int_t pdgCode = TMath::Abs(tau->PID);
   if(pdgCode != 15) return -1;
 
   if(momentum.Pt() <= fPTMin || TMath::Abs(momentum.Eta()) > fEtaMax) return -1;
@@ -81,17 +78,17 @@ Int_t TauTaggingPartonClassifier::GetCategory(TObject *object)
     throw runtime_error("tau's daughter index is greater than the ParticleInputArray size");
   }
 
-  for(i = tau->D1; i <= tau->D2; ++i)
+  for(Int_t i = tau->D1; i <= tau->D2; ++i)
   {
-    daughter1 = static_cast<Candidate *>(fParticleInputArray->At(i));
+    Candidate *daughter1 = static_cast<Candidate *>(fParticleInputArray->At(i));
     pdgCode = TMath::Abs(daughter1->PID);
     if(pdgCode == 11 || pdgCode == 13 || pdgCode == 15) return -1;
     else if(pdgCode == 24)
     {
      if(daughter1->D1 < 0) return -1;
-     for(j = daughter1->D1; j <= daughter1->D2; ++j)
+     for(Int_t j = daughter1->D1; j <= daughter1->D2; ++j)
      {
-       daughter2 = static_cast<Candidate*>(fParticleInputArray->At(j));
+       Candidate *daughter2 = static_cast<Candidate*>(fParticleInputArray->At(j));
        pdgCode = TMath::Abs(daughter2->PID);
        if(pdgCode == 11 || pdgCode == 13) return -1;
      }


### PR DESCRIPTION
Hi Delphes Team,

This pull request is not intended to be merged to the repository; please reject this PR.
But I just want to tell you a small comment on the coding style.

I believe, and strongly suggest that definitions of variables should be as close as possible to where they are used.
This makes the code easy to read because we don't have to go back to the definition part.
Also, with this convention, it is clear that `daughter1` and `pdgCode` are always with proper values, which makes this code "safe".
Note that this modification is no effect on performance because of optimization by compilers.

For more discussion, see http://programmers.stackexchange.com/questions/56585/

Sorry for a somewhat impertinent comment, but I like Delphes, and thus keep the code as secure and neat as possible...