### PR TITLE
Add Invert and Status options to PdgCodeFilter

### DIFF
--- a/modules/PdgCodeFilter.cc
+++ b/modules/PdgCodeFilter.cc
@@ -73,6 +73,11 @@ void PdgCodeFilter::Init()
   // PT threshold
   fPTMin = GetDouble("PTMin", 0.0);
 
+  fInvertPdg = GetBool("InvertPdg", false);
+
+  fRequireStatus = GetBool("RequireStatus", false);
+  fStatus = GetInt("Status", 1);
+
   // import input array
   fInputArray = ImportArray(GetString("InputArray", "Delphes/allParticles"));
   fItInputArray = fInputArray->MakeIterator();
@@ -108,6 +113,10 @@ void PdgCodeFilter::Process()
   Bool_t pass;
   Double_t pt;
 
+  const Bool_t requireStatus = fRequireStatus;
+  const Bool_t invertPdg = fInvertPdg;
+  const int reqStatus = fStatus;
+
   fItInputArray->Reset();
   while((candidate = static_cast<Candidate*>(fItInputArray->Next())))
   {
@@ -115,11 +124,13 @@ void PdgCodeFilter::Process()
     const TLorentzVector &candidateMomentum = candidate->Momentum;
     pt = candidateMomentum.Pt();
 
-    pass = kTRUE;
+    if(pt < fPTMin) continue;
+    if(requireStatus && (candidate->Status != reqStatus)) continue;
 
-    if(pt < fPTMin) pass = kFALSE;
+    pass = kTRUE;
     if(find(fPdgCodes.begin(), fPdgCodes.end(), pdgCode) != fPdgCodes.end()) pass = kFALSE;
 
+    if (invertPdg) pass = !pass;
     if(pass) fOutputArray->Add(candidate);
   }
 }

--- a/modules/PdgCodeFilter.h
+++ b/modules/PdgCodeFilter.h
@@ -49,6 +49,9 @@ public:
 private:
 
   Double_t fPTMin; //!
+  Bool_t fInvertPdg; //!
+  Bool_t fRequireStatus; //!
+  Int_t fStatus; //!
 
   std::vector<Int_t> fPdgCodes;
 


### PR DESCRIPTION
It is sometimes useful to output the truth record of a single
(non-stable) particle species, for example when considering an
exotic heavy resonance model. Presently the only way to do so
is to output the entire Delphes/allParticles array, which is
inefficient.

This patch adds the option `InvertPdg` to PdgCodeFilter, which causes
the PdgCodes specified to be *added* to the output array, rather
than removed. It also adds the options `RequireStatus` and `Status`,
for additional filtering based on the MC record status. If
`RequireStatus` is `true`, than only particles matching `Status` are
added to the output array.

This patch should be backwards compatible with existing usages of
PdgCodeFilter.