### PR TITLE
Change candidate momentum to reflect the perigee momentum

### DIFF
--- a/modules/ParticlePropagator.cc
+++ b/modules/ParticlePropagator.cc
@@ -238,6 +238,15 @@ void ParticlePropagator::Process()
       yd = (rc2 > 0.0) ? yd / rc2 : -999;
       zd = z + (TMath::Sqrt(xd*xd + yd*yd) - TMath::Sqrt(x*x + y*y))*pz/pt;
 
+      // use perigee momentum rather than original particle
+      // momentum, since the orignal particle momentum isn't known
+      double r_sign = std::signbit(r) ? 1 : -1;
+      px = r_sign * pt * (y_c / r_c);
+      py = r_sign * pt * (-x_c / r_c);
+      double eta_p = candidateMomentum.Eta();
+      double phi_p = std::atan2(py, px);
+      candidateMomentum.SetPtEtaPhiE(pt, eta_p, phi_p, candidateMomentum.E());
+
       // calculate impact paramater
       dxy = (xd*py - yd*px)/pt;
 


### PR DESCRIPTION
In the particle propagator the candidate momentum is currently copied
from the truth particle momentum. This is correct for prompt
particles, but inconsistent with most (all?) collider experiments,
which use the perigee momentum. The effect is especially noticeable in
low-pt tracks coming from a highly displaced vertex.

This commit fixes this by adjusting the candidate px and py, and by
extension the candidate dxy. The discrepancy should have a minimal
effect on most quantities, but could prevent problems which arise if
the user adds any vertex reconstruction algorithms to the standard
Delphes modules.
