### PR TITLE
Updating Ecal Resolution

### DIFF
--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -268,8 +268,10 @@ module Calorimeter Calorimeter {
   add EnergyFraction {3122} {0.3 0.7}
 
   # set ECalResolutionFormula {resolution formula as a function of eta and energy}
-  set ECalResolutionFormula {                  (abs(eta) <= 3.0) * sqrt(energy^2*0.007^2 + energy*0.07^2 + 0.35^2)  +
-                             (abs(eta) > 3.0 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
+  # Eta shape from arXiv:1306.2016, Energy shape from arXiv:1502.02701
+  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)  +
+                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)
+                             (abs(eta) > 2.5 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
 
   # set HCalResolutionFormula {resolution formula as a function of eta and energy}
   set HCalResolutionFormula {                  (abs(eta) <= 3.0) * sqrt(energy^2*0.050^2 + energy*1.50^2) +

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -269,8 +269,8 @@ module Calorimeter Calorimeter {
 
   # set ECalResolutionFormula {resolution formula as a function of eta and energy}
   # Eta shape from arXiv:1306.2016, Energy shape from arXiv:1502.02701
-  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)  +
-                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)
+  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2) +
+                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2) +
                              (abs(eta) > 2.5 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
 
   # set HCalResolutionFormula {resolution formula as a function of eta and energy}

--- a/cards/delphes_card_CMS_PileUp.tcl
+++ b/cards/delphes_card_CMS_PileUp.tcl
@@ -311,8 +311,8 @@ module Calorimeter Calorimeter {
 
   # set ECalResolutionFormula {resolution formula as a function of eta and energy}
   # Eta shape from arXiv:1306.2016, Energy shape from arXiv:1502.02701
-  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)  +
-                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)
+  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2) +
+                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2) +
                              (abs(eta) > 2.5 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
 
   # set HCalResolutionFormula {resolution formula as a function of eta and energy}

--- a/cards/delphes_card_CMS_PileUp.tcl
+++ b/cards/delphes_card_CMS_PileUp.tcl
@@ -310,8 +310,10 @@ module Calorimeter Calorimeter {
   add EnergyFraction {3122} {0.3 0.7}
 
   # set ECalResolutionFormula {resolution formula as a function of eta and energy}
-  set ECalResolutionFormula {                  (abs(eta) <= 3.0) * sqrt(energy^2*0.007^2 + energy*0.07^2 + 0.35^2) +
-                             (abs(eta) > 3.0 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
+  # Eta shape from arXiv:1306.2016, Energy shape from arXiv:1502.02701
+  set ECalResolutionFormula {                  (abs(eta) <= 1.5) * (1+0.64*eta^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)  +
+                             (abs(eta) > 1.5 && abs(eta) <= 2.5) * (2.16 + 5.6*(eta-2)^2) * sqrt(energy^2*0.008^2 + energy*0.11^2 + 0.40^2)
+                             (abs(eta) > 2.5 && abs(eta) <= 5.0) * sqrt(energy^2*0.107^2 + energy*2.08^2)}
 
   # set HCalResolutionFormula {resolution formula as a function of eta and energy}
   set HCalResolutionFormula {                  (abs(eta) <= 3.0) * sqrt(energy^2*0.050^2 + energy*1.50^2) +


### PR DESCRIPTION
New parametrization for the CMS ECAL resolution which was previously based on beam tests.
Eta shape from arXiv:1306.2016, Energy shape from arXiv:1502.02701