### PR TITLE
Increase include directory precedence of shipped fastjet headers.

### DIFF
--- a/external/fastjet/CMakeLists.txt
+++ b/external/fastjet/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${CMAKE_SOURCE_DIR}/external)
+include_directories(BEFORE ${CMAKE_SOURCE_DIR}/external)
 
 file(GLOB sources *.cc plugins/*/*.cc contribs/*/*.cc tools/*.cc)
 


### PR DESCRIPTION
This is needed to build in an environment where fastjet is already installed and in the include directories, e.g. when setting up an LCG view.