### PR TITLE
Add missing install targets

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -20,3 +20,10 @@ add_library(classes OBJECT ${sources} ClassesDict.cxx)
 
 # install public headers
 install(FILES ${headers} DESTINATION include/classes)
+
+# install pcms if they are created
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      ${PROJECT_BINARY_DIR}/classes/libClassesDict_rdict.pcm
+      DESTINATION lib)
+endif()

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -11,3 +11,10 @@ list(REMOVE_ITEM headers ${CMAKE_CURRENT_SOURCE_DIR}/DisplayLinkDef.h)
 DELPHES_GENERATE_DICTIONARY(DisplayDict ${headers} LINKDEF DisplayLinkDef.h)
 
 add_library(display OBJECT ${sources} DisplayDict.cxx)
+
+# install pcms if they are created
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      ${PROJECT_BINARY_DIR}/external/DisplayDict_rdict.pcm
+      DESTINATION lib)
+endif()

--- a/external/ExRootAnalysis/CMakeLists.txt
+++ b/external/ExRootAnalysis/CMakeLists.txt
@@ -12,4 +12,15 @@ DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict ${headers} LINKDEF ExRootAnalysis
 add_library(ExRootAnalysis OBJECT ${sources} ExRootAnalysisDict.cxx)
 
 # install headers needed by public Delphes headers to include/
-install(FILES ExRootTask.h ExRootConfReader.h DESTINATION include/ExRootAnalysis)
+install(FILES ExRootTask.h ExRootConfReader.h ExRootTreeWriter.h ExRootTreeBranch.h
+        DESTINATION include/ExRootAnalysis)
+
+# install all LinkDef files into the same folder to ease user environment
+install(FILES ExRootAnalysisLinkDef.h DESTINATION include)
+
+# install pcms if they are created
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      ${PROJECT_BINARY_DIR}/external/ExRootAnalysis/libExRootAnalysisDict_rdict.pcm
+      DESTINATION lib)
+endif()

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -19,4 +19,14 @@ list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/PileUpMergerPythia8.cc)
 add_library(modules OBJECT ${sources} FastJetDict.cxx ModulesDict.cxx)
 
 # install public headers
-install(FILES Delphes.h DESTINATION include/modules)
+install(FILES Delphes.h
+        DESTINATION include/modules
+)
+
+# install pcms if they are created
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      ${PROJECT_BINARY_DIR}/modules/libModulesDict_rdict.pcm
+      ${PROJECT_BINARY_DIR}/modules/libFastJetDict_rdict.pcm
+      DESTINATION lib)
+endif()


### PR DESCRIPTION
- header files for some ExRoot* classes
- all pcm files generated when ROOT version > 6.x

I'm not sure if there are other headers that should be installed, these cover the FCC use case.