### PR TITLE
Include all ExRootAnalysis headers and fix include paths

### DIFF
--- a/examples/CaloGrid.cpp
+++ b/examples/CaloGrid.cpp
@@ -10,7 +10,7 @@
 
 #include "display/Delphes3DGeometry.h"
 #include "classes/DelphesClasses.h"
-#include "external/ExRootAnalysis/ExRootConfReader.h"
+#include "ExRootAnalysis/ExRootConfReader.h"
 
 #include "TCanvas.h"
 #include "TStyle.h"

--- a/external/ExRootAnalysis/CMakeLists.txt
+++ b/external/ExRootAnalysis/CMakeLists.txt
@@ -12,8 +12,18 @@ DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict ${headers} LINKDEF ExRootAnalysis
 add_library(ExRootAnalysis OBJECT ${sources} ExRootAnalysisDict.cxx)
 
 # install headers needed by public Delphes headers to include/
-install(FILES ExRootTask.h ExRootConfReader.h ExRootTreeWriter.h ExRootTreeBranch.h
-        DESTINATION include/ExRootAnalysis)
+install(FILES
+  ExRootClassifier.h
+  ExRootConfReader.h
+  ExRootFilter.h
+  ExRootProgressBar.h
+  ExRootResult.h
+  ExRootTask.h
+  ExRootTreeBranch.h
+  ExRootTreeReader.h
+  ExRootTreeWriter.h
+  ExRootUtilities.h
+  DESTINATION include/ExRootAnalysis)
 
 # install all LinkDef files into the same folder to ease user environment
 install(FILES ExRootAnalysisLinkDef.h DESTINATION include)


### PR DESCRIPTION
When the headers are installed by `make install`, they are installed in:
```
$INSTALL_PREFIX/include/ExRootAnalysis
```
yet some of the examples (though not all!) searched for the headers in `include/external/ExRootAnalysis`.  As a result, these examples can only be compiled from the Delphes source folder, or if the Delphes source is included. This patch fixes this and makes sure that `ExRootAnalysis/<header>.h` is used.

In addition, all ExRootAnalysis headers are now installed by `make install`. Before, only some headers were installed (I don't know why some but not all were installed, some of the example even relied on headers which weren't installed).

Please let me know if there's anything you would like me to amend in the pull request.  Additionally, if there was a reason to not include certain ExRootAnalysis headers, please let me know and I'll fix that.