### PR TITLE
Install all headers from modules/ and display/

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(classes OBJECT ${sources} ClassesDict.cxx)
 # install public headers
 install(FILES ${headers} DESTINATION include/classes)
 
+# install all LinkDef files into the same folder to ease user environment
+install(FILES ClassesLinkDef.h DESTINATION include)
+
 # install pcms if they are created
 if (${ROOT_VERSION} GREATER 6)
   install(FILES

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -12,6 +12,12 @@ DELPHES_GENERATE_DICTIONARY(DisplayDict ${headers} LINKDEF DisplayLinkDef.h)
 
 add_library(display OBJECT ${sources} DisplayDict.cxx)
 
+# install public headers
+install(FILES ${headers} DESTINATION include/display)
+
+# install all LinkDef files into the same folder to ease user environment
+install(FILES DisplayLinkDef.h DESTINATION include)
+
 # install pcms if they are created
 if (${ROOT_VERSION} GREATER 6)
   install(FILES

--- a/external/ExRootAnalysis/CMakeLists.txt
+++ b/external/ExRootAnalysis/CMakeLists.txt
@@ -12,18 +12,7 @@ DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict ${headers} LINKDEF ExRootAnalysis
 add_library(ExRootAnalysis OBJECT ${sources} ExRootAnalysisDict.cxx)
 
 # install headers needed by public Delphes headers to include/
-install(FILES
-  ExRootClassifier.h
-  ExRootConfReader.h
-  ExRootFilter.h
-  ExRootProgressBar.h
-  ExRootResult.h
-  ExRootTask.h
-  ExRootTreeBranch.h
-  ExRootTreeReader.h
-  ExRootTreeWriter.h
-  ExRootUtilities.h
-  DESTINATION include/ExRootAnalysis)
+install(FILES ${headers} DESTINATION include/ExRootAnalysis)
 
 # install all LinkDef files into the same folder to ease user environment
 install(FILES ExRootAnalysisLinkDef.h DESTINATION include)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -19,9 +19,7 @@ list(REMOVE_ITEM sources ${CMAKE_CURRENT_SOURCE_DIR}/PileUpMergerPythia8.cc)
 add_library(modules OBJECT ${sources} FastJetDict.cxx ModulesDict.cxx)
 
 # install public headers
-install(FILES Delphes.h
-        DESTINATION include/modules
-)
+install(FILES Delphes.h DESTINATION include/modules)
 
 # install pcms if they are created
 if (${ROOT_VERSION} GREATER 6)


### PR DESCRIPTION
This brings both of those directories inline with what was already done with `classes/`.

If there are any headers which preferably should not be installed, let me know and I'll amend the pull request.