### PR TITLE
Set RPATH for installed libraries for all non-system paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # the RPATH to be used when installing, but only if it's not a system directory
 LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-IF("${isSystemDir}" STREQUAL "-1")
+IF(${isSystemDir} EQUAL -1)
    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-ENDIF("${isSystemDir}" STREQUAL "-1")
+ENDIF(${isSystemDir} EQUAL -1)
 
 # Declare ROOT dependency
 find_package(ROOT COMPONENTS EG Eve Geom Gui GuiHtml GenVector Hist Physics Matrix Graf RIO Tree Gpad RGL MathCore)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,22 @@ project(Delphes)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DDROP_CGAL")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
+# Set up the RPATH so executables find the libraries even when installed in non-default location
+SET(CMAKE_MACOSX_RPATH 1)
+SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# Add the automatically determined parts of the RPATH which point to directories outside
+# the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+IF("${isSystemDir}" STREQUAL "-1")
+   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+ENDIF("${isSystemDir}" STREQUAL "-1")
+
 # Declare ROOT dependency
 find_package(ROOT COMPONENTS EG Eve Geom Gui GuiHtml GenVector Hist Physics Matrix Graf RIO Tree Gpad RGL MathCore)
 include(${ROOT_USE_FILE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,22 +5,26 @@ project(Delphes)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DDROP_CGAL")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
-# Set up the RPATH so executables find the libraries even when installed in non-default location
-SET(CMAKE_MACOSX_RPATH 1)
-SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
-SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# Set the runtime path of the libraries by default but allow to switch it off:
+option(SET_RPATH "Set runtime path of the ${project} libraries?" ON)
+IF(SET_RPATH)
+  # Set up the RPATH so executables find the libraries even when installed in non-default location
+  SET(CMAKE_MACOSX_RPATH 1)
+  SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+  SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
+  SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
-# Add the automatically determined parts of the RPATH which point to directories outside
-# the build tree to the install RPATH
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+  # Add the automatically determined parts of the RPATH which point to directories outside
+  # the build tree to the install RPATH
+  SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
-# the RPATH to be used when installing, but only if it's not a system directory
-LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-IF(${isSystemDir} EQUAL -1)
-   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-ENDIF(${isSystemDir} EQUAL -1)
-
+  # the RPATH to be used when installing, but only if it's not a system directory
+  LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+  IF(${isSystemDir} EQUAL -1)
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+  ENDIF(${isSystemDir} EQUAL -1)
+ENDIF(SET_RPATH)
+    
 # Declare ROOT dependency
 find_package(ROOT COMPONENTS EG Eve Geom Gui GuiHtml GenVector Hist Physics Matrix Graf RIO Tree Gpad RGL MathCore)
 include(${ROOT_USE_FILE})


### PR DESCRIPTION
With the current CMake setup, it is not possible to install delphes in a custom path since the libraries are not found by the executables due to the missing RPATH setting.

To demonstrate:
```
$ git clone git@github.com:delphes/delphes.git
$ cd delphes && mkddir build && cd build/
$ cmake -DCMAKE_INSTALL_PREFIX=../install ..
[...]
-- Build files have been written to: /home/simonspa/software/delphes/build
$ make -j8
[...]
[ 98%] Linking CXX executable DelphesSTDHEP
[ 99%] Linking CXX executable DelphesLHEF
[100%] Linking CXX executable DelphesHepMC
[100%] Linking CXX executable DelphesROOT
[100%] Built target DelphesSTDHEP
[100%] Built target DelphesLHEF
[100%] Built target DelphesHepMC
[100%] Built target DelphesROOT
[100%] Linking CXX executable Validation
[100%] Built target Validation
$ make install
Install the project...
[...]
-- Installing: /home/simonspa/software/delphes/install/lib/libDelphes.so
-- Set runtime path of "/home/simonspa/software/delphes/install/lib/libDelphes.so" to ""
-- Installing: /home/simonspa/software/delphes/install/lib/libDelphesDisplay.so
-- Set runtime path of "/home/simonspa/software/delphes/install/lib/libDelphesDisplay.so" to ""
$ cd ../install/bin/
$ ./DelphesSTDHEP ../cards/delphes_card_ILD.tcl output.root input.hep
./DelphesSTDHEP: error while loading shared libraries: libDelphes.so: cannot open shared object file: No such file or directory
```

After adding the RPATH configuration to CMake, the library paths are resolved without problems:
```
$ make install
-- Installing: /home/simonspa/software/delphes/install/lib/libDelphes.so
-- Set runtime path of "/home/simonspa/software/delphes/install/lib/libDelphes.so" to "/home/simonspa/software/delphes/install/lib:/opt/root5/lib"
-- Installing: /home/simonspa/software/delphes/install/lib/libDelphesDisplay.so
-- Set runtime path of "/home/simonspa/software/delphes/install/lib/libDelphesDisplay.so" to "/home/simonspa/software/delphes/install/lib:/opt/root5/lib"
$ cd ../install/bin
$ ./DelphesSTDHEP ../cards/delphes_card_ILD.tcl output.root input.hep
[...]
** Reading input.hep
** ERROR: can't open input.hep
```

Cheers,
Simon