### PR TITLE
Correctly check ROOT version

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(classes OBJECT ${sources} ClassesDict.cxx)
 install(FILES ${headers} DESTINATION include/classes)
 
 # install pcms if they are created
-if (${ROOT_VERSION} GREATER 6)
+if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
   install(FILES
       ${PROJECT_BINARY_DIR}/classes/libClassesDict_rdict.pcm
       DESTINATION lib)

--- a/display/CMakeLists.txt
+++ b/display/CMakeLists.txt
@@ -13,7 +13,7 @@ DELPHES_GENERATE_DICTIONARY(DisplayDict ${headers} LINKDEF DisplayLinkDef.h)
 add_library(display OBJECT ${sources} DisplayDict.cxx)
 
 # install pcms if they are created
-if (${ROOT_VERSION} GREATER 6)
+if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
   install(FILES
       ${PROJECT_BINARY_DIR}/display/libDisplayDict_rdict.pcm
       DESTINATION lib)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -24,7 +24,7 @@ install(FILES Delphes.h
 )
 
 # install pcms if they are created
-if (${ROOT_VERSION} GREATER 6)
+if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
   install(FILES
       ${PROJECT_BINARY_DIR}/modules/libModulesDict_rdict.pcm
       ${PROJECT_BINARY_DIR}/modules/libFastJetDict_rdict.pcm


### PR DESCRIPTION
Previously the check may not have worked when using ROOT 6.0.0. Also, the check now uses the recommended `VERSION_LESS` instead of a normal `LESS` CMake condition.
