### PR TITLE
Fix override warnings

### DIFF
--- a/external/ExRootAnalysis/ExRootTreeBranch.cc
+++ b/external/ExRootAnalysis/ExRootTreeBranch.cc
@@ -81,10 +81,10 @@ TObject *ExRootTreeBranch::NewEntry()
 
 //------------------------------------------------------------------------------
 
-void ExRootTreeBranch::Clear()
+void ExRootTreeBranch::Clear(Option_t *option)
 {
   fSize = 0;
-  if(fData) fData->Clear();
+  if(fData) fData->Clear(option);
 }
 
 //------------------------------------------------------------------------------

--- a/external/ExRootAnalysis/ExRootTreeBranch.h
+++ b/external/ExRootAnalysis/ExRootTreeBranch.h
@@ -23,7 +23,7 @@ public:
   ~ExRootTreeBranch();
 
   TObject *NewEntry();
-  void Clear();
+  virtual void Clear(Option_t *option="");
 
 private:
 

--- a/external/ExRootAnalysis/ExRootTreeWriter.cc
+++ b/external/ExRootAnalysis/ExRootTreeWriter.cc
@@ -58,20 +58,30 @@ void ExRootTreeWriter::Fill()
 
 //------------------------------------------------------------------------------
 
-void ExRootTreeWriter::Write()
+Int_t ExRootTreeWriter::Write(const char *name, Int_t option, Int_t bufsize) const
 {
-  fFile = fTree ? fTree->GetCurrentFile() : 0;
-  if(fFile) fFile->Write();
+  if (fTree != 0) {
+    return fTree->GetCurrentFile()->Write(name, option, bufsize);
+  }
+  return 0;
 }
 
 //------------------------------------------------------------------------------
 
-void ExRootTreeWriter::Clear()
+Int_t ExRootTreeWriter::Write(const char *name, Int_t option, Int_t bufsize)
+{
+  // forward call to const version of this function
+  return static_cast<const ExRootTreeWriter*>(this)->Write(name, option, bufsize);
+}
+
+//------------------------------------------------------------------------------
+
+void ExRootTreeWriter::Clear(Option_t *option)
 {
   set<ExRootTreeBranch*>::iterator itBranches;
   for(itBranches = fBranches.begin(); itBranches != fBranches.end(); ++itBranches)
   {
-    (*itBranches)->Clear();
+    (*itBranches)->Clear(option);
   }
 }
 

--- a/external/ExRootAnalysis/ExRootTreeWriter.h
+++ b/external/ExRootAnalysis/ExRootTreeWriter.h
@@ -30,9 +30,10 @@ public:
 
   ExRootTreeBranch *NewBranch(const char *name, TClass *cl);
 
-  void Clear();
+  virtual void Clear(Option_t *option = "");
   void Fill();
-  void Write();
+  virtual Int_t Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+  virtual Int_t Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
 
 private:
 

--- a/modules/Delphes.cc
+++ b/modules/Delphes.cc
@@ -88,9 +88,9 @@ Delphes::~Delphes()
 
 //------------------------------------------------------------------------------
 
-void Delphes::Clear()
+void Delphes::Clear(Option_t* option)
 {
-  if(fFactory) fFactory->Clear();
+  if(fFactory) fFactory->Clear(option);
 }
 
 //------------------------------------------------------------------------------

--- a/modules/Delphes.h
+++ b/modules/Delphes.h
@@ -48,7 +48,7 @@ public:
   
   DelphesFactory *GetFactory() const { return fFactory; }
 
-  void Clear();
+  virtual void Clear(Option_t* option = "");
 
   virtual void Init();
   virtual void Process();


### PR DESCRIPTION
Previously, these function implementations were emitting warnings in client code when compiling against Delphes: They were overriding virtual functions with non-virtual functions. To properly override the ROOT arguments had to be added. This also means that now options can be passed along to the ROOT functions if so desired. I suspect that other classes are affected which just aren't used in the FCC code base.