### PR TITLE
attempt to add basic support for long-lived particles

### DIFF
--- a/modules/ParticlePropagator.h
+++ b/modules/ParticlePropagator.h
@@ -49,7 +49,7 @@ public:
 
 private:
 
-  Double_t fRadius, fRadius2, fHalfLength;
+  Double_t fRadius, fRadius2, fRadiusMax, fHalfLength, fHalfLengthMax;
   Double_t fBz;
 
   TIterator *fItInputArray; //!


### PR DESCRIPTION
This patch adds two parameters (RadiusMax and HalfLengthMax) to ParticlePropagator. These parameters can be used to keep decay products of the long-lived particles.

More details about the long-lived particles can be found in the following ticket:
https://cp3.irmp.ucl.ac.be/projects/delphes/ticket/1084