### PR TITLE
Update genMakefile.tcl to avoid conflicting access

### DIFF
--- a/doc/genMakefile.tcl
+++ b/doc/genMakefile.tcl
@@ -412,8 +412,7 @@ dist:
 	@mkdir -p $(@D)
 	@echo ">> Generating $@"
 	@rootcint -f $@ -c -Iexternal $<
-	@echo "#define private public" > $@.arch
-	@echo "#define protected public" >> $@.arch
+	@echo " " > $@.arch
 	@mv $@ $@.base
 	@cat $@.arch $< $@.base > $@
 	@rm $@.arch $@.base


### PR DESCRIPTION
When I try to compile Delphes originally, I get this error message:

```
error: ‘struct std::__cxx11::basic_stringbuf<_CharT, _Traits, _Alloc>::__xfer_bufptrs’ redeclared with different access
       struct __xfer_bufptrs
```

Making the changes in this proposal gets rid of those errors.