### PR TITLE
Add pythia8 dependancy to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,9 @@ include_directories(${tricktrack_INCLUDE_DIR})
 include_directories($ENV{EIGEN_INCLUDE_DIR})
 
 # WJF: Declare Pythia8 dependancy
+find_package(Pythia8)
 if(PYTHIA8_FOUND)
-  find_package(Pythia8)
+  message(STATUS "Pythia8 found")
   include_directories(${PYTHIA8_INCLUDE_DIRS})
   set(LIBS ${LIBS} ${PYTHIA8_LIBRARIES})
 endif(PYTHIA8_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,21 +25,14 @@ IF(SET_RPATH)
   ENDIF(${isSystemDir} EQUAL -1)
 ENDIF(SET_RPATH)
     
-# WJF: add path to place where Find*.cmake files can be found (for external libraries)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # Declare ROOT dependency
 find_package(ROOT COMPONENTS EG Eve Geom Gui GuiHtml GenVector Hist Physics Matrix Graf RIO Tree Gpad RGL MathCore)
 include(${ROOT_USE_FILE})
 
-# WJF: Declare TrickTrack dependency
-find_package(tricktrack)
-include_directories(${tricktrack_INCLUDE_DIR})
 
-# WJF: Declare Eigen dependency 
-include_directories($ENV{EIGEN_INCLUDE_DIR})
-
-# WJF: Declare Pythia8 dependancy
+# Declare Pythia8 dependancy
 find_package(Pythia8)
 if(PYTHIA8_FOUND)
   message(STATUS "Pythia8 found")
@@ -73,7 +66,6 @@ add_subdirectory(external)
 add_subdirectory(modules)
 add_subdirectory(readers)
 add_subdirectory(cards)
-add_subdirectory(analysis) # WJF: add for my analysis code 
 
 add_library(Delphes SHARED
   $<TARGET_OBJECTS:classes> 
@@ -99,7 +91,7 @@ add_library(DelphesDisplay SHARED
 target_link_Libraries(Delphes ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 target_link_Libraries(DelphesDisplay ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 if(PYTHIA8_FOUND)
-  target_link_libraries(Delphes ${LIBS}) #WJF: add (needed for DelphesPythia8)
+  target_link_libraries(Delphes ${LIBS}) # needed for DelphesPythia8
 endif(PYTHIA8_FOUND)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,12 @@ include_directories(${tricktrack_INCLUDE_DIR})
 include_directories($ENV{EIGEN_INCLUDE_DIR})
 
 # WJF: Declare Pythia8 dependancy
-#include_directories($ENV{PYTHIA_INCLUDE_DIR})
-find_package(Pythia8)
-include_directories(${PYTHIA8_INCLUDE_DIRS})
-set(LIBS ${LIBS} ${PYTHIA8_LIBRARIES})
+if(PYTHIA8_FOUND)
+  find_package(Pythia8)
+  include_directories(${PYTHIA8_INCLUDE_DIRS})
+  set(LIBS ${LIBS} ${PYTHIA8_LIBRARIES})
+endif(PYTHIA8_FOUND)
 
-# WJF test
 
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR "lib")
@@ -72,6 +72,7 @@ add_subdirectory(external)
 add_subdirectory(modules)
 add_subdirectory(readers)
 add_subdirectory(cards)
+add_subdirectory(analysis) # WJF: add for my analysis code 
 
 add_library(Delphes SHARED
   $<TARGET_OBJECTS:classes> 
@@ -96,7 +97,9 @@ add_library(DelphesDisplay SHARED
 
 target_link_Libraries(Delphes ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 target_link_Libraries(DelphesDisplay ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
-target_link_libraries(Delphes ${LIBS})
+if(PYTHIA8_FOUND)
+  target_link_libraries(Delphes ${LIBS}) #WJF: add (needed for DelphesPythia8)
+endif(PYTHIA8_FOUND)
 
 
 install(TARGETS Delphes DelphesDisplay DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,27 @@ IF(SET_RPATH)
   ENDIF(${isSystemDir} EQUAL -1)
 ENDIF(SET_RPATH)
     
+# WJF: add path to place where Find*.cmake files can be found (for external libraries)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
 # Declare ROOT dependency
 find_package(ROOT COMPONENTS EG Eve Geom Gui GuiHtml GenVector Hist Physics Matrix Graf RIO Tree Gpad RGL MathCore)
 include(${ROOT_USE_FILE})
+
+# WJF: Declare TrickTrack dependency
+find_package(tricktrack)
+include_directories(${tricktrack_INCLUDE_DIR})
+
+# WJF: Declare Eigen dependency 
+include_directories($ENV{EIGEN_INCLUDE_DIR})
+
+# WJF: Declare Pythia8 dependancy
+#include_directories($ENV{PYTHIA_INCLUDE_DIR})
+find_package(Pythia8)
+include_directories(${PYTHIA8_INCLUDE_DIRS})
+set(LIBS ${LIBS} ${PYTHIA8_LIBRARIES})
+
+# WJF test
 
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR "lib")
@@ -40,6 +58,8 @@ function(DELPHES_GENERATE_DICTIONARY dictionary)
     ROOT_GENERATE_DICTIONARY(${dictionary} MODULE ${dictionary} ${ARGN})
   endif()
 endfunction()
+
+
 
 # Declare position of all other externals needed
 set(DelphesExternals_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/external)
@@ -76,5 +96,7 @@ add_library(DelphesDisplay SHARED
 
 target_link_Libraries(Delphes ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
 target_link_Libraries(DelphesDisplay ${ROOT_LIBRARIES} ${ROOT_COMPONENT_LIBRARIES})
+target_link_libraries(Delphes ${LIBS})
+
 
 install(TARGETS Delphes DelphesDisplay DESTINATION lib)

--- a/cmake/Modules/FindPythia8.cmake
+++ b/cmake/Modules/FindPythia8.cmake
@@ -1,0 +1,56 @@
+# Find the Pythia8 includes and library.
+#
+# This module defines
+# PYTHIA8_INCLUDE_DIR   where to locate Pythia.h file
+# PYTHIA8_LIBRARY       where to find the libpythia8 library
+# PYTHIA8_<lib>_LIBRARY Addicional libraries
+# PYTHIA8_LIBRARIES     (not cached) the libraries to link against to use Pythia8
+# PYTHIA8_FOUND         if false, you cannot build anything that requires Pythia8
+# PYTHIA8_VERSION       version of Pythia8 if found
+
+set(_pythia8dirs
+    ${PYTHIA8_DIR}
+    $ENV{PYTHIA8_DIR}
+    /usr
+    /opt/pythia8)
+
+find_path(PYTHIA8_INCLUDE_DIR
+          NAMES Pythia8/Pythia.h
+          HINTS ${_pythia8dirs}
+          PATH_SUFFIXES include include/Pythia8 include/pythia8
+          DOC "Specify the directory containing Pythia.h.")
+
+find_library(PYTHIA8_LIBRARY
+             NAMES pythia8 Pythia8
+             HINTS ${_pythia8dirs}
+             PATH_SUFFIXES lib
+             DOC "Specify the Pythia8 library here.")
+
+find_library(PYTHIA8_hepmcinterface_LIBRARY
+             NAMES hepmcinterface pythia8tohepmc
+             HINTS ${_pythia8dirs}
+             PATH_SUFFIXES lib)
+
+find_library(PYTHIA8_lhapdfdummy_LIBRARY
+             NAMES lhapdfdummy
+             HINTS ${_pythia8dirs}
+             PATH_SUFFIXES lib)
+
+foreach(_lib PYTHIA8_LIBRARY PYTHIA8_hepmcinterface_LIBRARY PYTHIA8_lhapdfdummy_LIBRARY)
+  if(${_lib})
+    set(PYTHIA8_LIBRARIES ${PYTHIA8_LIBRARIES} ${${_lib}})
+  endif()
+endforeach()
+set(PYTHIA8_INCLUDE_DIRS ${PYTHIA8_INCLUDE_DIR} ${PYTHIA8_INCLUDE_DIR}/Pythia8 )
+
+find_path(PYTHIA8_DATA 
+          NAMES MainProgramSettings.xml
+          HINTS ${_pythia8dirs}
+          PATH_SUFFIXES xmldoc)
+
+# handle the QUIETLY and REQUIRED arguments and set PYTHIA8_FOUND to TRUE if
+# all listed variables are TRUE
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Pythia8 DEFAULT_MSG PYTHIA8_INCLUDE_DIR PYTHIA8_LIBRARY)
+mark_as_advanced(PYTHIA8_INCLUDE_DIR PYTHIA8_LIBRARY PYTHIA8_hepmcinterface_LIBRARY PYTHIA8_lhapdfdummy_LIBRARY)

--- a/cmake/Modules/FindPythia8.cmake
+++ b/cmake/Modules/FindPythia8.cmake
@@ -9,6 +9,8 @@
 # PYTHIA8_VERSION       version of Pythia8 if found
 
 set(_pythia8dirs
+    ${PYTHIA8}
+    $ENV{PYTHIA8}
     ${PYTHIA8_DIR}
     $ENV{PYTHIA8_DIR}
     /usr

--- a/readers/CMakeLists.txt
+++ b/readers/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB executables RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 # TODO: implement switch to enable CMSSW, ProMC and Pythia8 if present
 list(REMOVE_ITEM executables DelphesCMSFWLite.cpp)
 list(REMOVE_ITEM executables DelphesProMC.cpp)
-list(REMOVE_ITEM executables DelphesPythia8.cpp)
+#list(REMOVE_ITEM executables DelphesPythia8.cpp)
 
 # build all executables and put them into bin/
 foreach(sourcefile ${executables})

--- a/readers/CMakeLists.txt
+++ b/readers/CMakeLists.txt
@@ -8,7 +8,9 @@ file(GLOB executables RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 # TODO: implement switch to enable CMSSW, ProMC and Pythia8 if present
 list(REMOVE_ITEM executables DelphesCMSFWLite.cpp)
 list(REMOVE_ITEM executables DelphesProMC.cpp)
-#list(REMOVE_ITEM executables DelphesPythia8.cpp)
+if(NOT PYTHIA8_FOUND)
+  list(REMOVE_ITEM executables DelphesPythia8.cpp)
+endif()
 
 # build all executables and put them into bin/
 foreach(sourcefile ${executables})


### PR DESCRIPTION
I added the CMake setup for Pythia8 such that DelphesPythia8 can be built. This required adding a new directory "cmake/Modules" with a new file "FindPythia8.cmake" which is used to find where Pythia8 is installed. The environment variable PYTHIA8 need only be set to the path of where Pythia8 is installed (so it's the same as the current setup with the existing Makefile). Alternatively, the environment variable PYTHIA8_DIR may be used to the same effect. 

Note that I copied the FindPythia8.cmake from ROOT (it's available on the web). 

If Pythia8 is not installed (or the environment variable is not set) then there is an IF statement to prevent DelphesPythia8 from being built. 