### PR TITLE
Adding TauWeight variable

### DIFF
--- a/classes/DelphesClasses.cc
+++ b/classes/DelphesClasses.cc
@@ -124,7 +124,7 @@ Candidate::Candidate() :
   ClusterIndex(-1), ClusterNDF(0), ClusterSigma(0), SumPT2(0), BTVSumPT2(0), GenDeltaZ(0), GenSumPT2(0),
   Flavor(0), FlavorAlgo(0), FlavorPhys(0),
   BTag(0), BTagAlgo(0), BTagPhys(0),
-  TauTag(0), Eem(0.0), Ehad(0.0),
+  TauTag(0), TauWeight(0.0), Eem(0.0), Ehad(0.0),
   DeltaEta(0.0), DeltaPhi(0.0),
   Momentum(0.0, 0.0, 0.0, 0.0),
   Position(0.0, 0.0, 0.0, 0.0),
@@ -275,6 +275,7 @@ void Candidate::Copy(TObject &obj) const
   object.BTagAlgo = BTagAlgo;
   object.BTagPhys = BTagPhys;
   object.TauTag = TauTag;
+  object.TauWeight = TauWeight;
   object.Eem = Eem;
   object.Ehad = Ehad;
   object.Edges[0] = Edges[0];
@@ -399,6 +400,7 @@ void Candidate::Clear(Option_t* option)
   BTagAlgo = 0;
   BTagPhys = 0;
   TauTag = 0;
+  TauWeight = 0.0;
   Eem = 0.0;
   Ehad = 0.0;
   Edges[0] = 0.0;

--- a/classes/DelphesClasses.h
+++ b/classes/DelphesClasses.h
@@ -372,6 +372,7 @@ public:
   UInt_t BTagPhys; // 0 or 1 for a jet that has been tagged as containing a heavy quark
 
   UInt_t TauTag; // 0 or 1 for a jet that has been tagged as a tau
+  Float_t TauWeight; // probability for jet to be identified as tau
 
   Int_t Charge; // tau charge
 
@@ -555,6 +556,7 @@ public:
   UInt_t BTagPhys;
 
   UInt_t TauTag;
+  Float_t TauWeight;
 
   Float_t Eem;
   Float_t Ehad;

--- a/modules/TauTagging.cc
+++ b/modules/TauTagging.cc
@@ -254,8 +254,10 @@ void TauTagging::Process()
     formula = itEfficiencyMap->second;
 
     // apply an efficency formula
-    jet->TauTag |= (gRandom->Uniform() <= formula->Eval(pt, eta, phi, e)) << fBitNumber;
-    
+    Double_t eff=formula->Eval(pt, eta, phi, e);
+    jet->TauTag |= (gRandom->Uniform() <= eff) << fBitNumber;
+    jet->TauWeight = eff;     
+
     // set tau charge
     jet->Charge = charge;
   }

--- a/modules/TreeWriter.cc
+++ b/modules/TreeWriter.cc
@@ -649,6 +649,7 @@ void TreeWriter::ProcessJets(ExRootTreeBranch *branch, TObjArray *array)
     entry->BTagPhys = candidate->BTagPhys;
 
     entry->TauTag = candidate->TauTag;
+    entry->TauWeight = candidate->TauWeight;
 
     entry->Charge = candidate->Charge;
 


### PR DESCRIPTION
Allows to weight events based on tau tag probability (instead of rejecting/accepting events based on a random number) and thus gain in effective statistics.