### PR TITLE
Added missing examples to install target

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(
   ${CMAKE_SOURCE_DIR}
-  ${DelphesExternals_INCLUDE_DIR} 
+  ${DelphesExternals_INCLUDE_DIR}
 )
 
 file(GLOB executables RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
@@ -16,3 +16,7 @@ endforeach()
 
 # take all other relevant files and put them into examples/
 install(FILES ${macros} DESTINATION examples)
+install(DIRECTORY ExternalFastJet DESTINATION examples)
+if(PYTHIA8_FOUND)
+  install(DIRECTORY Pythia8 DESTINATION examples)
+endif()


### PR DESCRIPTION
Currently, only macros directly under the `examples` directory are copied to the install directory:
```bash
delphes$ tree -L 1 examples/
examples/
├── DelphesBrowser.C
├── DenseTracks.C
├── EventDisplay.C
├── Example1.C
├── Example2.C
├── Example3.C
├── Example4.C
├── Example5.C
├── MemoryUsage.C
├── ProcessingTime.C
└── vertexAnalyzer.C
```

This patch adds `ExternalFastJet` and, if PYTHIA8 is found, `Pythia8`:
```bash
delphes$ tree -L 2 examples/
tree -L 2 examples/
examples/
├── DelphesBrowser.C
├── DenseTracks.C
├── EventDisplay.C
├── Example1.C
├── Example2.C
├── Example3.C
├── Example4.C
├── Example5.C
├── ExternalFastJet #<-- new
│   ├── ExternalFastJetBasic.cpp
│   ├── ExternalFastJetHepMC.cpp
│   ├── Makefile
│   └── README
├── MemoryUsage.C
├── ProcessingTime.C
├── Pythia8 #<-- new
│   ├── configLHE.cmnd
│   ├── configNoLHE.cmnd
│   ├── configParticleGun.cmnd
│   ├── events.lhe
│   ├── generatePileUp.cmnd
│   └── generatePileUpCMS.cmnd
└── vertexAnalyzer.C
```

The tutorial is then also valid for out-of-source builds:
https://cp3.irmp.ucl.ac.be/projects/delphes/wiki/WorkBook/Pythia8