### PR TITLE
Added missing Pythia ROOT dictionary to install location

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -30,4 +30,9 @@ if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
       ${PROJECT_BINARY_DIR}/modules/libModulesDict_rdict.pcm
       ${PROJECT_BINARY_DIR}/modules/libFastJetDict_rdict.pcm
       DESTINATION lib)
+  if(PYTHIA8_FOUND)
+    install(FILES
+      ${PROJECT_BINARY_DIR}/modules/libPythia8Dict_rdict.pcm
+    DESTINATION lib)
+  endif()
 endif()


### PR DESCRIPTION
When compiling Delphes with Pythia & ROOT `modules/libPythia8Dict_rdict.pcm` is built but not installed.
This PR makes sure that the dictionary ends up in the install location if Pythia8 is found. 