### PR TITLE
adjust isolation criteria of the CLICdet cards

### DIFF
--- a/cards/CLIC/CLICdet_BTagging_JER.tcl
+++ b/cards/CLIC/CLICdet_BTagging_JER.tcl
@@ -1,0 +1,463 @@
+module BTagging BTagging_JER_WP50_R05N2 {
+	set JetInputArray JetMomentumSmearing_VLCR05N2/JER_VLCjetsR05N2
+	set BitNumber 0
+
+	# 50% efficiency working point
+    # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+    # PDG code = the highest PDG code of a quark or gluon inside DeltaR cone around jet axis
+    # gluon's PDG code has the lowest priority
+
+	# based on CLICdp-Note-2014-002
+
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R05N2 {
+	set JetInputArray JetMomentumSmearing_VLCR05N2/JER_VLCjetsR05N2
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R05N2 {
+	set JetInputArray JetMomentumSmearing_VLCR05N2/JER_VLCjetsR05N2
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R05N3 {
+	set JetInputArray JetMomentumSmearing_VLCR05N3/JER_VLCjetsR05N3
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R05N3 {
+	set JetInputArray JetMomentumSmearing_VLCR05N3/JER_VLCjetsR05N3
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R05N3 {
+	set JetInputArray JetMomentumSmearing_VLCR05N3/JER_VLCjetsR05N3
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R05N4 {
+	set JetInputArray JetMomentumSmearing_VLCR05N4/JER_VLCjetsR05N4
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R05N4 {
+	set JetInputArray JetMomentumSmearing_VLCR05N4/JER_VLCjetsR05N4
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R05N4 {
+	set JetInputArray JetMomentumSmearing_VLCR05N4/JER_VLCjetsR05N4
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R05N5 {
+	set JetInputArray JetMomentumSmearing_VLCR05N5/JER_VLCjetsR05N5
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R05N5 {
+	set JetInputArray JetMomentumSmearing_VLCR05N5/JER_VLCjetsR05N5
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R05N5 {
+	set JetInputArray JetMomentumSmearing_VLCR05N5/JER_VLCjetsR05N5
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R05N6 {
+	set JetInputArray JetMomentumSmearing_VLCR05N6/JER_VLCjetsR05N6
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R05N6 {
+	set JetInputArray JetMomentumSmearing_VLCR05N6/JER_VLCjetsR05N6
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R05N6 {
+	set JetInputArray JetMomentumSmearing_VLCR05N6/JER_VLCjetsR05N6
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R07N2 {
+	set JetInputArray JetMomentumSmearing_VLCR07N2/JER_VLCjetsR07N2
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R07N2 {
+	set JetInputArray JetMomentumSmearing_VLCR07N2/JER_VLCjetsR07N2
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R07N2 {
+	set JetInputArray JetMomentumSmearing_VLCR07N2/JER_VLCjetsR07N2
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R07N3 {
+	set JetInputArray JetMomentumSmearing_VLCR07N3/JER_VLCjetsR07N3
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R07N3 {
+	set JetInputArray JetMomentumSmearing_VLCR07N3/JER_VLCjetsR07N3
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R07N3 {
+	set JetInputArray JetMomentumSmearing_VLCR07N3/JER_VLCjetsR07N3
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R07N4 {
+	set JetInputArray JetMomentumSmearing_VLCR07N4/JER_VLCjetsR07N4
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R07N4 {
+	set JetInputArray JetMomentumSmearing_VLCR07N4/JER_VLCjetsR07N4
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R07N4 {
+	set JetInputArray JetMomentumSmearing_VLCR07N4/JER_VLCjetsR07N4
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R07N5 {
+	set JetInputArray JetMomentumSmearing_VLCR07N5/JER_VLCjetsR07N5
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R07N5 {
+	set JetInputArray JetMomentumSmearing_VLCR07N5/JER_VLCjetsR07N5
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R07N5 {
+	set JetInputArray JetMomentumSmearing_VLCR07N5/JER_VLCjetsR07N5
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R07N6 {
+	set JetInputArray JetMomentumSmearing_VLCR07N6/JER_VLCjetsR07N6
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R07N6 {
+	set JetInputArray JetMomentumSmearing_VLCR07N6/JER_VLCjetsR07N6
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R07N6 {
+	set JetInputArray JetMomentumSmearing_VLCR07N6/JER_VLCjetsR07N6
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R10N2 {
+	set JetInputArray JetMomentumSmearing_VLCR10N2/JER_VLCjetsR10N2
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R10N2 {
+	set JetInputArray JetMomentumSmearing_VLCR10N2/JER_VLCjetsR10N2
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R10N2 {
+	set JetInputArray JetMomentumSmearing_VLCR10N2/JER_VLCjetsR10N2
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R10N3 {
+	set JetInputArray JetMomentumSmearing_VLCR10N3/JER_VLCjetsR10N3
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R10N3 {
+	set JetInputArray JetMomentumSmearing_VLCR10N3/JER_VLCjetsR10N3
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R10N3 {
+	set JetInputArray JetMomentumSmearing_VLCR10N3/JER_VLCjetsR10N3
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R10N4 {
+	set JetInputArray JetMomentumSmearing_VLCR10N4/JER_VLCjetsR10N4
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R10N4 {
+	set JetInputArray JetMomentumSmearing_VLCR10N4/JER_VLCjetsR10N4
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R10N4 {
+	set JetInputArray JetMomentumSmearing_VLCR10N4/JER_VLCjetsR10N4
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R10N5 {
+	set JetInputArray JetMomentumSmearing_VLCR10N5/JER_VLCjetsR10N5
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R10N5 {
+	set JetInputArray JetMomentumSmearing_VLCR10N5/JER_VLCjetsR10N5
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R10N5 {
+	set JetInputArray JetMomentumSmearing_VLCR10N5/JER_VLCjetsR10N5
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R10N6 {
+	set JetInputArray JetMomentumSmearing_VLCR10N6/JER_VLCjetsR10N6
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R10N6 {
+	set JetInputArray JetMomentumSmearing_VLCR10N6/JER_VLCjetsR10N6
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R10N6 {
+	set JetInputArray JetMomentumSmearing_VLCR10N6/JER_VLCjetsR10N6
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12N2 {
+	set JetInputArray JetMomentumSmearing_VLCR12N2/JER_VLCjetsR12N2
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R12N2 {
+	set JetInputArray JetMomentumSmearing_VLCR12N2/JER_VLCjetsR12N2
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12N2 {
+	set JetInputArray JetMomentumSmearing_VLCR12N2/JER_VLCjetsR12N2
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12N3 {
+	set JetInputArray JetMomentumSmearing_VLCR12N3/JER_VLCjetsR12N3
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R12N3 {
+	set JetInputArray JetMomentumSmearing_VLCR12N3/JER_VLCjetsR12N3
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12N3 {
+	set JetInputArray JetMomentumSmearing_VLCR12N3/JER_VLCjetsR12N3
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12N4 {
+	set JetInputArray JetMomentumSmearing_VLCR12N4/JER_VLCjetsR12N4
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R12N4 {
+	set JetInputArray JetMomentumSmearing_VLCR12N4/JER_VLCjetsR12N4
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12N4 {
+	set JetInputArray JetMomentumSmearing_VLCR12N4/JER_VLCjetsR12N4
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12N5 {
+	set JetInputArray JetMomentumSmearing_VLCR12N5/JER_VLCjetsR12N5
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R12N5 {
+	set JetInputArray JetMomentumSmearing_VLCR12N5/JER_VLCjetsR12N5
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12N5 {
+	set JetInputArray JetMomentumSmearing_VLCR12N5/JER_VLCjetsR12N5
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12N6 {
+	set JetInputArray JetMomentumSmearing_VLCR12N6/JER_VLCjetsR12N6
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R12N6 {
+	set JetInputArray JetMomentumSmearing_VLCR12N6/JER_VLCjetsR12N6
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12N6 {
+	set JetInputArray JetMomentumSmearing_VLCR12N6/JER_VLCjetsR12N6
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15N2 {
+	set JetInputArray JetMomentumSmearing_VLCR15N2/JER_VLCjetsR15N2
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R15N2 {
+	set JetInputArray JetMomentumSmearing_VLCR15N2/JER_VLCjetsR15N2
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15N2 {
+	set JetInputArray JetMomentumSmearing_VLCR15N2/JER_VLCjetsR15N2
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15N3 {
+	set JetInputArray JetMomentumSmearing_VLCR15N3/JER_VLCjetsR15N3
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R15N3 {
+	set JetInputArray JetMomentumSmearing_VLCR15N3/JER_VLCjetsR15N3
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15N3 {
+	set JetInputArray JetMomentumSmearing_VLCR15N3/JER_VLCjetsR15N3
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15N4 {
+	set JetInputArray JetMomentumSmearing_VLCR15N4/JER_VLCjetsR15N4
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R15N4 {
+	set JetInputArray JetMomentumSmearing_VLCR15N4/JER_VLCjetsR15N4
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15N4 {
+	set JetInputArray JetMomentumSmearing_VLCR15N4/JER_VLCjetsR15N4
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15N5 {
+	set JetInputArray JetMomentumSmearing_VLCR15N5/JER_VLCjetsR15N5
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R15N5 {
+	set JetInputArray JetMomentumSmearing_VLCR15N5/JER_VLCjetsR15N5
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15N5 {
+	set JetInputArray JetMomentumSmearing_VLCR15N5/JER_VLCjetsR15N5
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15N6 {
+	set JetInputArray JetMomentumSmearing_VLCR15N6/JER_VLCjetsR15N6
+	set BitNumber 0
+	source CLIC/CLICdet_BTag_50.tcl
+}
+module BTagging BTagging_JER_WP70_R15N6 {
+	set JetInputArray JetMomentumSmearing_VLCR15N6/JER_VLCjetsR15N6
+	set BitNumber 1
+	source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15N6 {
+	set JetInputArray JetMomentumSmearing_VLCR15N6/JER_VLCjetsR15N6
+	set BitNumber 2
+	source CLIC/CLICdet_BTag_90.tcl
+}
+
+########################
+# inclusive clustering
+########################
+
+module BTagging BTagging_JER_WP50_R05_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR05_inclusive/JER_VLCjetsR05_inclusive                         
+ set BitNumber 0                                                                               
+ source CLIC/CLICdet_BTag_50.tcl                                                                    
+ }                                                                                             
+module BTagging BTagging_JER_WP70_R05_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR05_inclusive/JER_VLCjetsR05_inclusive                         
+ set BitNumber 1                                                                               
+ source CLIC/CLICdet_BTag_70.tcl                                                                    
+}                                                                                              
+module BTagging BTagging_JER_WP90_R05_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR05_inclusive/JER_VLCjetsR05_inclusive                         
+ set BitNumber 2                                                                               
+ source CLIC/CLICdet_BTag_90.tcl                                                                    
+}                                                                                              
+module BTagging BTagging_JER_WP50_R07_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR07_inclusive/JER_VLCjetsR07_inclusive                         
+ set BitNumber 0                                                                               
+ source CLIC/CLICdet_BTag_50.tcl                                                                    
+ }                                                                                             
+module BTagging BTagging_JER_WP70_R07_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR07_inclusive/JER_VLCjetsR07_inclusive                         
+ set BitNumber 1                                                                               
+ source CLIC/CLICdet_BTag_70.tcl                                                                    
+}                                                                                              
+module BTagging BTagging_JER_WP90_R07_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR07_inclusive/JER_VLCjetsR07_inclusive                         
+ set BitNumber 2                                                                               
+ source CLIC/CLICdet_BTag_90.tcl                                                                    
+}                                                                                              
+module BTagging BTagging_JER_WP50_R10_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR10_inclusive/JER_VLCjetsR10_inclusive                         
+ set BitNumber 0                                                                               
+ source CLIC/CLICdet_BTag_50.tcl                                                                    
+ }                                                                                             
+module BTagging BTagging_JER_WP70_R10_inclusive {                                                   
+ set JetInputArray JetMomentumSmearing_VLCR10_inclusive/JER_VLCjetsR10_inclusive                         
+ set BitNumber 1                                                                               
+ source CLIC/CLICdet_BTag_70.tcl                                                                    
+}
+module BTagging BTagging_JER_WP90_R10_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR10_inclusive/JER_VLCjetsR10_inclusive
+ set BitNumber 2
+ source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R12_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR12_inclusive/JER_VLCjetsR12_inclusive
+ set BitNumber 0
+ source CLIC/CLICdet_BTag_50.tcl
+ }
+module BTagging BTagging_JER_WP70_R12_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR12_inclusive/JER_VLCjetsR12_inclusive
+ set BitNumber 1
+ source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R12_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR12_inclusive/JER_VLCjetsR12_inclusive
+ set BitNumber 2
+ source CLIC/CLICdet_BTag_90.tcl
+}
+module BTagging BTagging_JER_WP50_R15_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR15_inclusive/JER_VLCjetsR15_inclusive
+ set BitNumber 0
+ source CLIC/CLICdet_BTag_50.tcl
+ }
+module BTagging BTagging_JER_WP70_R15_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR15_inclusive/JER_VLCjetsR15_inclusive
+ set BitNumber 1
+ source CLIC/CLICdet_BTag_70.tcl
+}
+module BTagging BTagging_JER_WP90_R15_inclusive {
+ set JetInputArray JetMomentumSmearing_VLCR15_inclusive/JER_VLCjetsR15_inclusive
+ set BitNumber 2
+ source CLIC/CLICdet_BTag_90.tcl
+}

--- a/cards/CLIC/CLICdet_JetFlavorAssociation_JER.tcl
+++ b/cards/CLIC/CLICdet_JetFlavorAssociation_JER.tcl
@@ -1,0 +1,371 @@
+module JetFlavorAssociation JetFlavorAssociation_JER_R05N2 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05N2/JER_VLCjetsR05N2
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R05N3 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05N3/JER_VLCjetsR05N3
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R05N4 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05N4/JER_VLCjetsR05N4
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R05N5 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05N5/JER_VLCjetsR05N5
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R05N6 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05N6/JER_VLCjetsR05N6
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+
+#R07
+module JetFlavorAssociation JetFlavorAssociation_JER_R07N2 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07N2/JER_VLCjetsR07N2
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R07N3 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07N3/JER_VLCjetsR07N3
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R07N4 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07N4/JER_VLCjetsR07N4
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R07N5 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07N5/JER_VLCjetsR07N5
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R07N6 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07N6/JER_VLCjetsR07N6
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+
+
+#R10
+module JetFlavorAssociation JetFlavorAssociation_JER_R10N2 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10N2/JER_VLCjetsR10N2
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R10N3 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10N3/JER_VLCjetsR10N3
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R10N4 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10N4/JER_VLCjetsR10N4
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R10N5 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10N5/JER_VLCjetsR10N5
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R10N6 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10N6/JER_VLCjetsR10N6
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+
+
+# R 12
+module JetFlavorAssociation JetFlavorAssociation_JER_R12N2 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12N2/JER_VLCjetsR12N2
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R12N3 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12N3/JER_VLCjetsR12N3
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R12N4 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12N4/JER_VLCjetsR12N4
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R12N5 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12N5/JER_VLCjetsR12N5
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R12N6 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12N6/JER_VLCjetsR12N6
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+
+# R15
+module JetFlavorAssociation JetFlavorAssociation_JER_R15N2 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15N2/JER_VLCjetsR15N2
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R15N3 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15N3/JER_VLCjetsR15N3
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R15N4 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15N4/JER_VLCjetsR15N4
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R15N5 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15N5/JER_VLCjetsR15N5
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R15N6 {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15N6/JER_VLCjetsR15N6
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+
+module JetFlavorAssociation JetFlavorAssociation_JER_R05_inclusive {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR05_inclusive/JER_VLCjetsR05_inclusive
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R07_inclusive {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR07_inclusive/JER_VLCjetsR07_inclusive
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R10_inclusive {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR10_inclusive/JER_VLCjetsR10_inclusive
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R12_inclusive {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR12_inclusive/JER_VLCjetsR12_inclusive
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}
+module JetFlavorAssociation JetFlavorAssociation_JER_R15_inclusive {
+
+    set PartonInputArray Delphes/partons
+    set ParticleInputArray Delphes/allParticles
+    set ParticleLHEFInputArray Delphes/allParticlesLHEF
+    set JetInputArray JetMomentumSmearing_VLCR15_inclusive/JER_VLCjetsR15_inclusive
+
+    set DeltaR 0.5
+    set PartonPTMin 1.0
+    set PartonEtaMax 2.5
+
+}

--- a/cards/CLIC/CLICdet_TauTagging_JER.tcl
+++ b/cards/CLIC/CLICdet_TauTagging_JER.tcl
@@ -1,0 +1,609 @@
+module TauTagging TauTagging_JER_R05N2 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+    set JetInputArray JetMomentumSmearing_VLCR05N2/JER_VLCjetsR05N2
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+    # add EfficiencyFormula {abs(PDG code)} {efficiency formula as a function of eta and pt}
+    # default efficiency formula (misidentification rate)
+    add EfficiencyFormula {0} {0.03}
+    # efficiency formula for tau-jets
+    
+    add EfficiencyFormula {15} { 
+	(pt < 5) * (0.0) +
+	(pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+    } 
+} 
+
+module TauTagging TauTagging_JER_R05N3 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR05N3/JER_VLCjetsR05N3
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R05N4 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR05N4/JER_VLCjetsR05N4
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R05N5 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR05N5/JER_VLCjetsR05N5
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R05N6 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR05N6/JER_VLCjetsR05N6
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R07N2 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07N2/JER_VLCjetsR07N2
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R07N3 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07N3/JER_VLCjetsR07N3
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R07N4 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07N4/JER_VLCjetsR07N4
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R07N5 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07N5/JER_VLCjetsR07N5
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R07N6 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07N6/JER_VLCjetsR07N6
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R10N2 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10N2/JER_VLCjetsR10N2
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R10N3 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10N3/JER_VLCjetsR10N3
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R10N4 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10N4/JER_VLCjetsR10N4
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R10N5 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10N5/JER_VLCjetsR10N5
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R10N6 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10N6/JER_VLCjetsR10N6
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R12N2 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12N2/JER_VLCjetsR12N2
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R12N3 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12N3/JER_VLCjetsR12N3
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R12N4 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12N4/JER_VLCjetsR12N4
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R12N5 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12N5/JER_VLCjetsR12N5
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R12N6 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12N6/JER_VLCjetsR12N6
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R15N2 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15N2/JER_VLCjetsR15N2
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R15N3 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15N3/JER_VLCjetsR15N3
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R15N4 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15N4/JER_VLCjetsR15N4
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R15N5 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15N5/JER_VLCjetsR15N5
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+module TauTagging TauTagging_JER_R15N6 {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15N6/JER_VLCjetsR15N6
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+
+module TauTagging TauTagging_JER_R05_inclusive {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR05_inclusive/JER_VLCjetsR05_inclusive
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+
+module TauTagging TauTagging_JER_R07_inclusive {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR07_inclusive/JER_VLCjetsR07_inclusive
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+
+module TauTagging TauTagging_JER_R10_inclusive {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR10_inclusive/JER_VLCjetsR10_inclusive
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+
+module TauTagging TauTagging_JER_R12_inclusive {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR12_inclusive/JER_VLCjetsR12_inclusive
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+
+
+module TauTagging TauTagging_JER_R15_inclusive {
+ set ParticleInputArray Delphes/allParticles
+ set PartonInputArray Delphes/partons
+ set JetInputArray JetMomentumSmearing_VLCR15_inclusive/JER_VLCjetsR15_inclusive
+ set DeltaR 0.5
+ set TauPTMin 1.0
+ set TauEtaMax 4.0
+ add EfficiencyFormula {0} {0.03} 
+ add EfficiencyFormula {15} { 
+ (pt < 5) * (0.0) +
+ (pt >=5 && pt < 12.5) * (0.84) +
+	(pt >=12.5 && pt < 25) * (0.79) +
+	(pt >=25 && pt < 50) * (0.74) +
+	(pt >=50 && pt < 75) * (0.66) +
+	(pt >=75 && pt < 125) * (0.61) +
+	(pt >=125 && pt < 250) * (0.51) +
+	(pt >=250 ) * (0.36)
+ } 
+ } 
+

--- a/cards/delphes_card_CLICdet_Stage1.tcl
+++ b/cards/delphes_card_CLICdet_Stage1.tcl
@@ -1,6 +1,8 @@
 #######################################
 # CLICdet model
-# based on CLICdp-Note-2017-001
+# based on arXiv:1812.07337 and
+# CLICdp-Note-2017-001
+#
 # Ulrike Schnoor ulrike.schnoor@cern.ch
 # 
 # For the low energy stage of
@@ -10,6 +12,11 @@
 # use exclusive clustering with njets
 # according to final state
 # 
+# c-tagging capabilities of CLICdet are
+# not yet implemented here. Please
+# contact us if you want to use it.
+#######################################
+
 #######################################
 # Order of execution of various modules
 #######################################
@@ -706,11 +713,11 @@ module Isolation PhotonIsolation {
 
     set OutputArray photons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
 
 #####################
@@ -804,11 +811,11 @@ module Isolation ElectronIsolation {
 
     set OutputArray electrons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
 
 #################
@@ -843,11 +850,11 @@ module Isolation MuonIsolation {
 
     set OutputArray muons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.25
+    set PTRatioMax 0.2
 }
 
 

--- a/cards/delphes_card_CLICdet_Stage2.tcl
+++ b/cards/delphes_card_CLICdet_Stage2.tcl
@@ -130,117 +130,154 @@ set ExecutionPath {
        
 
     JetFlavorAssociation_R05N2
-	JetFlavorAssociation_R05N3
-	JetFlavorAssociation_R05N4
-	JetFlavorAssociation_R05N5
-	JetFlavorAssociation_R05N6
-	
-	JetFlavorAssociation_R07N2
-	JetFlavorAssociation_R07N3
-	JetFlavorAssociation_R07N4
-	JetFlavorAssociation_R07N5
-	JetFlavorAssociation_R07N6
-
-	JetFlavorAssociation_R10N2
-	JetFlavorAssociation_R10N3
-	JetFlavorAssociation_R10N4
-	JetFlavorAssociation_R10N5
-	JetFlavorAssociation_R10N6
-
-	JetFlavorAssociation_R12N2
-	JetFlavorAssociation_R12N3
-	JetFlavorAssociation_R12N4
-	JetFlavorAssociation_R12N5
-	JetFlavorAssociation_R12N6
-
-	JetFlavorAssociation_R15N2
-	JetFlavorAssociation_R15N3
-	JetFlavorAssociation_R15N4
-	JetFlavorAssociation_R15N5
-        JetFlavorAssociation_R15N6
-
-        JetFlavorAssociation_R05_inclusive
-        JetFlavorAssociation_R07_inclusive
-        JetFlavorAssociation_R10_inclusive
-        JetFlavorAssociation_R12_inclusive
-        JetFlavorAssociation_R15_inclusive
-
+    JetFlavorAssociation_R05N3
+    JetFlavorAssociation_R05N4
+    JetFlavorAssociation_R05N5
+    JetFlavorAssociation_R05N6
     
-	BTaggingWP50_R05N2
-	BTaggingWP70_R05N2
-	BTaggingWP90_R05N2
-	BTaggingWP50_R05N3
-	BTaggingWP70_R05N3
-	BTaggingWP90_R05N3
-	BTaggingWP50_R05N4
-	BTaggingWP70_R05N4
-	BTaggingWP90_R05N4
-	BTaggingWP50_R05N5
-	BTaggingWP70_R05N5
-	BTaggingWP90_R05N5
-	BTaggingWP50_R05N6
-	BTaggingWP70_R05N6
-	BTaggingWP90_R05N6
-	BTaggingWP50_R07N2
-	BTaggingWP70_R07N2
-	BTaggingWP90_R07N2
-	BTaggingWP50_R07N3
-	BTaggingWP70_R07N3
-	BTaggingWP90_R07N3
-	BTaggingWP50_R07N4
-	BTaggingWP70_R07N4
-	BTaggingWP90_R07N4
-	BTaggingWP50_R07N5
-	BTaggingWP70_R07N5
-	BTaggingWP90_R07N5
-	BTaggingWP50_R07N6
-	BTaggingWP70_R07N6
-	BTaggingWP90_R07N6
-	BTaggingWP50_R10N2
-	BTaggingWP70_R10N2
-	BTaggingWP90_R10N2
-	BTaggingWP50_R10N3
-	BTaggingWP70_R10N3
-	BTaggingWP90_R10N3
-	BTaggingWP50_R10N4
-	BTaggingWP70_R10N4
-	BTaggingWP90_R10N4
-	BTaggingWP50_R10N5
-	BTaggingWP70_R10N5
-	BTaggingWP90_R10N5
-	BTaggingWP50_R10N6
-	BTaggingWP70_R10N6
-	BTaggingWP90_R10N6
-	BTaggingWP50_R12N2
-	BTaggingWP70_R12N2
-	BTaggingWP90_R12N2
-	BTaggingWP50_R12N3
-	BTaggingWP70_R12N3
-	BTaggingWP90_R12N3
-	BTaggingWP50_R12N4
-	BTaggingWP70_R12N4
-	BTaggingWP90_R12N4
-	BTaggingWP50_R12N5
-	BTaggingWP70_R12N5
-	BTaggingWP90_R12N5
-	BTaggingWP50_R12N6
-	BTaggingWP70_R12N6
-	BTaggingWP90_R12N6
-	BTaggingWP50_R15N2
-	BTaggingWP70_R15N2
-	BTaggingWP90_R15N2
-	BTaggingWP50_R15N3
-	BTaggingWP70_R15N3
-	BTaggingWP90_R15N3
-	BTaggingWP50_R15N4
-	BTaggingWP70_R15N4
-	BTaggingWP90_R15N4
-	BTaggingWP50_R15N5
-	BTaggingWP70_R15N5
-	BTaggingWP90_R15N5
-	BTaggingWP50_R15N6
-	BTaggingWP70_R15N6
-	BTaggingWP90_R15N6
+    JetFlavorAssociation_R07N2
+    JetFlavorAssociation_R07N3
+    JetFlavorAssociation_R07N4
+    JetFlavorAssociation_R07N5
+    JetFlavorAssociation_R07N6
+    
+    JetFlavorAssociation_R10N2
+    JetFlavorAssociation_R10N3
+    JetFlavorAssociation_R10N4
+    JetFlavorAssociation_R10N5
+    JetFlavorAssociation_R10N6
+    
+    JetFlavorAssociation_R12N2
+    JetFlavorAssociation_R12N3
+    JetFlavorAssociation_R12N4
+    JetFlavorAssociation_R12N5
+    JetFlavorAssociation_R12N6
+    
+    JetFlavorAssociation_R15N2
+    JetFlavorAssociation_R15N3
+    JetFlavorAssociation_R15N4
+    JetFlavorAssociation_R15N5
+    JetFlavorAssociation_R15N6
+    
+    JetFlavorAssociation_R05_inclusive
+    JetFlavorAssociation_R07_inclusive
+    JetFlavorAssociation_R10_inclusive
+    JetFlavorAssociation_R12_inclusive
+    JetFlavorAssociation_R15_inclusive
+
+
+    JetFlavorAssociation_JER_R05N2
+    JetFlavorAssociation_JER_R05N3
+    JetFlavorAssociation_JER_R05N4
+    JetFlavorAssociation_JER_R05N5
+    JetFlavorAssociation_JER_R05N6
+    
+    JetFlavorAssociation_JER_R07N2
+    JetFlavorAssociation_JER_R07N3
+    JetFlavorAssociation_JER_R07N4
+    JetFlavorAssociation_JER_R07N5
+    JetFlavorAssociation_JER_R07N6
+    
+    JetFlavorAssociation_JER_R10N2
+    JetFlavorAssociation_JER_R10N3
+    JetFlavorAssociation_JER_R10N4
+    JetFlavorAssociation_JER_R10N5
+    JetFlavorAssociation_JER_R10N6
+    
+    JetFlavorAssociation_JER_R12N2
+    JetFlavorAssociation_JER_R12N3
+    JetFlavorAssociation_JER_R12N4
+    JetFlavorAssociation_JER_R12N5
+    JetFlavorAssociation_JER_R12N6
+    
+    JetFlavorAssociation_JER_R15N2
+    JetFlavorAssociation_JER_R15N3
+    JetFlavorAssociation_JER_R15N4
+    JetFlavorAssociation_JER_R15N5
+    JetFlavorAssociation_JER_R15N6
+    
+    JetFlavorAssociation_JER_R05_inclusive
+    JetFlavorAssociation_JER_R07_inclusive
+    JetFlavorAssociation_JER_R10_inclusive
+    JetFlavorAssociation_JER_R12_inclusive
+    JetFlavorAssociation_JER_R15_inclusive
+    
+    
+    BTaggingWP50_R05N2
+    BTaggingWP70_R05N2
+    BTaggingWP90_R05N2
+    BTaggingWP50_R05N3
+    BTaggingWP70_R05N3
+    BTaggingWP90_R05N3
+    BTaggingWP50_R05N4
+    BTaggingWP70_R05N4
+    BTaggingWP90_R05N4
+    BTaggingWP50_R05N5
+    BTaggingWP70_R05N5
+    BTaggingWP90_R05N5
+    BTaggingWP50_R05N6
+    BTaggingWP70_R05N6
+    BTaggingWP90_R05N6
+    BTaggingWP50_R07N2
+    BTaggingWP70_R07N2
+    BTaggingWP90_R07N2
+    BTaggingWP50_R07N3
+    BTaggingWP70_R07N3
+    BTaggingWP90_R07N3
+    BTaggingWP50_R07N4
+    BTaggingWP70_R07N4
+    BTaggingWP90_R07N4
+    BTaggingWP50_R07N5
+    BTaggingWP70_R07N5
+    BTaggingWP90_R07N5
+    BTaggingWP50_R07N6
+    BTaggingWP70_R07N6
+    BTaggingWP90_R07N6
+    BTaggingWP50_R10N2
+    BTaggingWP70_R10N2
+    BTaggingWP90_R10N2
+    BTaggingWP50_R10N3
+    BTaggingWP70_R10N3
+    BTaggingWP90_R10N3
+    BTaggingWP50_R10N4
+    BTaggingWP70_R10N4
+    BTaggingWP90_R10N4
+    BTaggingWP50_R10N5
+    BTaggingWP70_R10N5
+    BTaggingWP90_R10N5
+    BTaggingWP50_R10N6
+    BTaggingWP70_R10N6
+    BTaggingWP90_R10N6
+    BTaggingWP50_R12N2
+    BTaggingWP70_R12N2
+    BTaggingWP90_R12N2
+    BTaggingWP50_R12N3
+    BTaggingWP70_R12N3
+    BTaggingWP90_R12N3
+    BTaggingWP50_R12N4
+    BTaggingWP70_R12N4
+    BTaggingWP90_R12N4
+    BTaggingWP50_R12N5
+    BTaggingWP70_R12N5
+    BTaggingWP90_R12N5
+    BTaggingWP50_R12N6
+    BTaggingWP70_R12N6
+    BTaggingWP90_R12N6
+    BTaggingWP50_R15N2
+    BTaggingWP70_R15N2
+    BTaggingWP90_R15N2
+    BTaggingWP50_R15N3
+    BTaggingWP70_R15N3
+    BTaggingWP90_R15N3
+    BTaggingWP50_R15N4
+    BTaggingWP70_R15N4
+    BTaggingWP90_R15N4
+    BTaggingWP50_R15N5
+    BTaggingWP70_R15N5
+    BTaggingWP90_R15N5
+    BTaggingWP50_R15N6
+    BTaggingWP70_R15N6
+    BTaggingWP90_R15N6
     BTaggingWP50_R05_inclusive
     BTaggingWP70_R05_inclusive
     BTaggingWP90_R05_inclusive
@@ -257,6 +294,99 @@ set ExecutionPath {
     BTaggingWP70_R15_inclusive
     BTaggingWP90_R15_inclusive
 
+
+
+    BTagging_JER_WP50_R05N2
+    BTagging_JER_WP70_R05N2
+    BTagging_JER_WP90_R05N2
+    BTagging_JER_WP50_R05N3
+    BTagging_JER_WP70_R05N3
+    BTagging_JER_WP90_R05N3
+    BTagging_JER_WP50_R05N4
+    BTagging_JER_WP70_R05N4
+    BTagging_JER_WP90_R05N4
+    BTagging_JER_WP50_R05N5
+    BTagging_JER_WP70_R05N5
+    BTagging_JER_WP90_R05N5
+    BTagging_JER_WP50_R05N6
+    BTagging_JER_WP70_R05N6
+    BTagging_JER_WP90_R05N6
+    BTagging_JER_WP50_R07N2
+    BTagging_JER_WP70_R07N2
+    BTagging_JER_WP90_R07N2
+    BTagging_JER_WP50_R07N3
+    BTagging_JER_WP70_R07N3
+    BTagging_JER_WP90_R07N3
+    BTagging_JER_WP50_R07N4
+    BTagging_JER_WP70_R07N4
+    BTagging_JER_WP90_R07N4
+    BTagging_JER_WP50_R07N5
+    BTagging_JER_WP70_R07N5
+    BTagging_JER_WP90_R07N5
+    BTagging_JER_WP50_R07N6
+    BTagging_JER_WP70_R07N6
+    BTagging_JER_WP90_R07N6
+    BTagging_JER_WP50_R10N2
+    BTagging_JER_WP70_R10N2
+    BTagging_JER_WP90_R10N2
+    BTagging_JER_WP50_R10N3
+    BTagging_JER_WP70_R10N3
+    BTagging_JER_WP90_R10N3
+    BTagging_JER_WP50_R10N4
+    BTagging_JER_WP70_R10N4
+    BTagging_JER_WP90_R10N4
+    BTagging_JER_WP50_R10N5
+    BTagging_JER_WP70_R10N5
+    BTagging_JER_WP90_R10N5
+    BTagging_JER_WP50_R10N6
+    BTagging_JER_WP70_R10N6
+    BTagging_JER_WP90_R10N6
+    BTagging_JER_WP50_R12N2
+    BTagging_JER_WP70_R12N2
+    BTagging_JER_WP90_R12N2
+    BTagging_JER_WP50_R12N3
+    BTagging_JER_WP70_R12N3
+    BTagging_JER_WP90_R12N3
+    BTagging_JER_WP50_R12N4
+    BTagging_JER_WP70_R12N4
+    BTagging_JER_WP90_R12N4
+    BTagging_JER_WP50_R12N5
+    BTagging_JER_WP70_R12N5
+    BTagging_JER_WP90_R12N5
+    BTagging_JER_WP50_R12N6
+    BTagging_JER_WP70_R12N6
+    BTagging_JER_WP90_R12N6
+    BTagging_JER_WP50_R15N2
+    BTagging_JER_WP70_R15N2
+    BTagging_JER_WP90_R15N2
+    BTagging_JER_WP50_R15N3
+    BTagging_JER_WP70_R15N3
+    BTagging_JER_WP90_R15N3
+    BTagging_JER_WP50_R15N4
+    BTagging_JER_WP70_R15N4
+    BTagging_JER_WP90_R15N4
+    BTagging_JER_WP50_R15N5
+    BTagging_JER_WP70_R15N5
+    BTagging_JER_WP90_R15N5
+    BTagging_JER_WP50_R15N6
+    BTagging_JER_WP70_R15N6
+    BTagging_JER_WP90_R15N6
+    BTagging_JER_WP50_R05_inclusive
+    BTagging_JER_WP70_R05_inclusive
+    BTagging_JER_WP90_R05_inclusive
+    BTagging_JER_WP50_R07_inclusive
+    BTagging_JER_WP70_R07_inclusive
+    BTagging_JER_WP90_R07_inclusive
+    BTagging_JER_WP50_R10_inclusive
+    BTagging_JER_WP70_R10_inclusive
+    BTagging_JER_WP90_R10_inclusive
+    BTagging_JER_WP50_R12_inclusive
+    BTagging_JER_WP70_R12_inclusive
+    BTagging_JER_WP90_R12_inclusive
+    BTagging_JER_WP50_R15_inclusive
+    BTagging_JER_WP70_R15_inclusive
+    BTagging_JER_WP90_R15_inclusive
+    
     
     TauTagging_R05N2
     TauTagging_R05N3
@@ -283,12 +413,42 @@ set ExecutionPath {
     TauTagging_R15N4
     TauTagging_R15N5
     TauTagging_R15N6
-
     TauTagging_R05_inclusive
     TauTagging_R07_inclusive
     TauTagging_R10_inclusive
     TauTagging_R12_inclusive
     TauTagging_R15_inclusive
+
+    TauTagging_JER_R05N2
+    TauTagging_JER_R05N3
+    TauTagging_JER_R05N4
+    TauTagging_JER_R05N5
+    TauTagging_JER_R05N6
+    TauTagging_JER_R07N2
+    TauTagging_JER_R07N3
+    TauTagging_JER_R07N4
+    TauTagging_JER_R07N5
+    TauTagging_JER_R07N6
+    TauTagging_JER_R10N2
+    TauTagging_JER_R10N3
+    TauTagging_JER_R10N4
+    TauTagging_JER_R10N5
+    TauTagging_JER_R10N6
+    TauTagging_JER_R12N2
+    TauTagging_JER_R12N3
+    TauTagging_JER_R12N4
+    TauTagging_JER_R12N5
+    TauTagging_JER_R12N6
+    TauTagging_JER_R15N2
+    TauTagging_JER_R15N3
+    TauTagging_JER_R15N4
+    TauTagging_JER_R15N5
+    TauTagging_JER_R15N6
+    TauTagging_JER_R05_inclusive
+    TauTagging_JER_R07_inclusive
+    TauTagging_JER_R10_inclusive
+    TauTagging_JER_R12_inclusive
+    TauTagging_JER_R15_inclusive
 
 
 
@@ -1006,6 +1166,7 @@ source CLIC/CLICdet_JetSmearing_1500.tcl
 ########################
 
 source  CLIC/CLICdet_JetFlavorAssociation.tcl
+source  CLIC/CLICdet_JetFlavorAssociation_JER.tcl
 
 ###########
 # b-tagging
@@ -1013,6 +1174,7 @@ source  CLIC/CLICdet_JetFlavorAssociation.tcl
 # based on CLICdp-Note-2014-002    
 
 source  CLIC/CLICdet_BTagging.tcl
+source  CLIC/CLICdet_BTagging_JER.tcl
 
 
 #############
@@ -1021,6 +1183,7 @@ source  CLIC/CLICdet_BTagging.tcl
 # based on LCD-2010-009
 
 source CLIC/CLICdet_TauTagging.tcl
+source CLIC/CLICdet_TauTagging_JER.tcl
 
 
 

--- a/cards/delphes_card_CLICdet_Stage2.tcl
+++ b/cards/delphes_card_CLICdet_Stage2.tcl
@@ -1,6 +1,8 @@
 #######################################
 # CLICdet model
-# based on CLICdp-Note-2017-001
+# based on arXiv:1812.07337 and
+# CLICdp-Note-2017-001
+#
 # Ulrike Schnoor ulrike.schnoor@cern.ch
 # 
 # For the intermediate energy stage of
@@ -10,6 +12,11 @@
 # use exclusive clustering with njets
 # according to final state
 # 
+# c-tagging capabilities of CLICdet are
+# not yet implemented here. Please
+# contact us if you want to use it.
+#######################################
+
 #######################################
 # Order of execution of various modules
 #######################################
@@ -738,11 +745,11 @@ module Isolation PhotonIsolation {
 
     set OutputArray photons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
 
 #####################
@@ -836,11 +843,11 @@ module Isolation ElectronIsolation {
 
     set OutputArray electrons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
 
 #################
@@ -874,11 +881,11 @@ module Isolation MuonIsolation {
 
     set OutputArray muons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.25
+    set PTRatioMax 0.2
 }
 
 

--- a/cards/delphes_card_CLICdet_Stage3.tcl
+++ b/cards/delphes_card_CLICdet_Stage3.tcl
@@ -1,8 +1,9 @@
 #######################################
 # CLICdet model
-# based on CLICdp-Note-2017-001
+# based on arXiv:1812.07337 and
+# CLICdp-Note-2017-001
+#
 # Ulrike Schnoor ulrike.schnoor@cern.ch
-# 
 # 
 # For the high energy stage of
 # CLIC: 3 TeV
@@ -10,7 +11,12 @@
 # Jet finding with Valencia algorithm:
 # use exclusive clustering with njets
 # according to final state
-# 
+#
+# c-tagging capabilities of CLICdet are
+# not yet implemented here. Please
+# contact us if you want to use it.
+#######################################
+
 #######################################
 # Order of execution of various modules
 #######################################
@@ -729,6 +735,7 @@ module Efficiency PhotonEfficiency {
 
 }
 
+
 ##################
 # Photon isolation
 ##################
@@ -739,12 +746,13 @@ module Isolation PhotonIsolation {
 
     set OutputArray photons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
+
 
 #####################
 # Electron efficiency
@@ -752,6 +760,7 @@ module Isolation PhotonIsolation {
 
 module Efficiency ElectronEfficiency {
     set InputArray ElectronFilter/electrons
+    #set InputArray ElectronDressing/electrons
     set OutputArray electrons
 
     # set EfficiencyFormula {efficiency formula as a function of eta and pt}
@@ -837,11 +846,11 @@ module Isolation ElectronIsolation {
 
     set OutputArray electrons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.12
+    set PTRatioMax 0.2
 }
 
 #################
@@ -875,11 +884,11 @@ module Isolation MuonIsolation {
 
     set OutputArray muons
 
-    set DeltaRMax 0.5
+    set DeltaRMax 0.1
 
     set PTMin 0.5
 
-    set PTRatioMax 0.25
+    set PTRatioMax 0.2
 }
 
 

--- a/cards/delphes_card_CLICdet_Stage3.tcl
+++ b/cards/delphes_card_CLICdet_Stage3.tcl
@@ -130,117 +130,152 @@ set ExecutionPath {
        
 
     JetFlavorAssociation_R05N2
-	JetFlavorAssociation_R05N3
-	JetFlavorAssociation_R05N4
-	JetFlavorAssociation_R05N5
-	JetFlavorAssociation_R05N6
-	
-	JetFlavorAssociation_R07N2
-	JetFlavorAssociation_R07N3
-	JetFlavorAssociation_R07N4
-	JetFlavorAssociation_R07N5
-	JetFlavorAssociation_R07N6
-
-	JetFlavorAssociation_R10N2
-	JetFlavorAssociation_R10N3
-	JetFlavorAssociation_R10N4
-	JetFlavorAssociation_R10N5
-	JetFlavorAssociation_R10N6
-
-	JetFlavorAssociation_R12N2
-	JetFlavorAssociation_R12N3
-	JetFlavorAssociation_R12N4
-	JetFlavorAssociation_R12N5
-	JetFlavorAssociation_R12N6
-
-	JetFlavorAssociation_R15N2
-	JetFlavorAssociation_R15N3
-	JetFlavorAssociation_R15N4
-	JetFlavorAssociation_R15N5
-        JetFlavorAssociation_R15N6
-
-        JetFlavorAssociation_R05_inclusive
-        JetFlavorAssociation_R07_inclusive
-        JetFlavorAssociation_R10_inclusive
-        JetFlavorAssociation_R12_inclusive
-        JetFlavorAssociation_R15_inclusive
-
+    JetFlavorAssociation_R05N3
+    JetFlavorAssociation_R05N4
+    JetFlavorAssociation_R05N5
+    JetFlavorAssociation_R05N6
     
-	BTaggingWP50_R05N2
-	BTaggingWP70_R05N2
-	BTaggingWP90_R05N2
-	BTaggingWP50_R05N3
-	BTaggingWP70_R05N3
-	BTaggingWP90_R05N3
-	BTaggingWP50_R05N4
-	BTaggingWP70_R05N4
-	BTaggingWP90_R05N4
-	BTaggingWP50_R05N5
-	BTaggingWP70_R05N5
-	BTaggingWP90_R05N5
-	BTaggingWP50_R05N6
-	BTaggingWP70_R05N6
-	BTaggingWP90_R05N6
-	BTaggingWP50_R07N2
-	BTaggingWP70_R07N2
-	BTaggingWP90_R07N2
-	BTaggingWP50_R07N3
-	BTaggingWP70_R07N3
-	BTaggingWP90_R07N3
-	BTaggingWP50_R07N4
-	BTaggingWP70_R07N4
-	BTaggingWP90_R07N4
-	BTaggingWP50_R07N5
-	BTaggingWP70_R07N5
-	BTaggingWP90_R07N5
-	BTaggingWP50_R07N6
-	BTaggingWP70_R07N6
-	BTaggingWP90_R07N6
-	BTaggingWP50_R10N2
-	BTaggingWP70_R10N2
-	BTaggingWP90_R10N2
-	BTaggingWP50_R10N3
-	BTaggingWP70_R10N3
-	BTaggingWP90_R10N3
-	BTaggingWP50_R10N4
-	BTaggingWP70_R10N4
-	BTaggingWP90_R10N4
-	BTaggingWP50_R10N5
-	BTaggingWP70_R10N5
-	BTaggingWP90_R10N5
-	BTaggingWP50_R10N6
-	BTaggingWP70_R10N6
-	BTaggingWP90_R10N6
-	BTaggingWP50_R12N2
-	BTaggingWP70_R12N2
-	BTaggingWP90_R12N2
-	BTaggingWP50_R12N3
-	BTaggingWP70_R12N3
-	BTaggingWP90_R12N3
-	BTaggingWP50_R12N4
-	BTaggingWP70_R12N4
-	BTaggingWP90_R12N4
-	BTaggingWP50_R12N5
-	BTaggingWP70_R12N5
-	BTaggingWP90_R12N5
-	BTaggingWP50_R12N6
-	BTaggingWP70_R12N6
-	BTaggingWP90_R12N6
-	BTaggingWP50_R15N2
-	BTaggingWP70_R15N2
-	BTaggingWP90_R15N2
-	BTaggingWP50_R15N3
-	BTaggingWP70_R15N3
-	BTaggingWP90_R15N3
-	BTaggingWP50_R15N4
-	BTaggingWP70_R15N4
-	BTaggingWP90_R15N4
-	BTaggingWP50_R15N5
-	BTaggingWP70_R15N5
-	BTaggingWP90_R15N5
-	BTaggingWP50_R15N6
-	BTaggingWP70_R15N6
-	BTaggingWP90_R15N6
+    JetFlavorAssociation_R07N2
+    JetFlavorAssociation_R07N3
+    JetFlavorAssociation_R07N4
+    JetFlavorAssociation_R07N5
+    JetFlavorAssociation_R07N6
+
+    JetFlavorAssociation_R10N2
+    JetFlavorAssociation_R10N3
+    JetFlavorAssociation_R10N4
+    JetFlavorAssociation_R10N5
+    JetFlavorAssociation_R10N6
+
+    JetFlavorAssociation_R12N2
+    JetFlavorAssociation_R12N3
+    JetFlavorAssociation_R12N4
+    JetFlavorAssociation_R12N5
+    JetFlavorAssociation_R12N6
+
+    JetFlavorAssociation_R15N2
+    JetFlavorAssociation_R15N3
+    JetFlavorAssociation_R15N4
+    JetFlavorAssociation_R15N5
+    JetFlavorAssociation_R15N6
+
+    JetFlavorAssociation_R05_inclusive
+    JetFlavorAssociation_R07_inclusive
+    JetFlavorAssociation_R10_inclusive
+    JetFlavorAssociation_R12_inclusive
+    JetFlavorAssociation_R15_inclusive
+
+    JetFlavorAssociation_JER_R05N2
+    JetFlavorAssociation_JER_R05N3
+    JetFlavorAssociation_JER_R05N4
+    JetFlavorAssociation_JER_R05N5
+    JetFlavorAssociation_JER_R05N6
+    
+    JetFlavorAssociation_JER_R07N2
+    JetFlavorAssociation_JER_R07N3
+    JetFlavorAssociation_JER_R07N4
+    JetFlavorAssociation_JER_R07N5
+    JetFlavorAssociation_JER_R07N6
+    
+    JetFlavorAssociation_JER_R10N2
+    JetFlavorAssociation_JER_R10N3
+    JetFlavorAssociation_JER_R10N4
+    JetFlavorAssociation_JER_R10N5
+    JetFlavorAssociation_JER_R10N6
+    
+    JetFlavorAssociation_JER_R12N2
+    JetFlavorAssociation_JER_R12N3
+    JetFlavorAssociation_JER_R12N4
+    JetFlavorAssociation_JER_R12N5
+    JetFlavorAssociation_JER_R12N6
+    
+    JetFlavorAssociation_JER_R15N2
+    JetFlavorAssociation_JER_R15N3
+    JetFlavorAssociation_JER_R15N4
+    JetFlavorAssociation_JER_R15N5
+    JetFlavorAssociation_JER_R15N6
+    
+    JetFlavorAssociation_JER_R05_inclusive
+    JetFlavorAssociation_JER_R07_inclusive
+    JetFlavorAssociation_JER_R10_inclusive
+    JetFlavorAssociation_JER_R12_inclusive
+    JetFlavorAssociation_JER_R15_inclusive
+    
+    BTaggingWP50_R05N2
+    BTaggingWP70_R05N2
+    BTaggingWP90_R05N2
+    BTaggingWP50_R05N3
+    BTaggingWP70_R05N3
+    BTaggingWP90_R05N3
+    BTaggingWP50_R05N4
+    BTaggingWP70_R05N4
+    BTaggingWP90_R05N4
+    BTaggingWP50_R05N5
+    BTaggingWP70_R05N5
+    BTaggingWP90_R05N5
+    BTaggingWP50_R05N6
+    BTaggingWP70_R05N6
+    BTaggingWP90_R05N6
+    BTaggingWP50_R07N2
+    BTaggingWP70_R07N2
+    BTaggingWP90_R07N2
+    BTaggingWP50_R07N3
+    BTaggingWP70_R07N3
+    BTaggingWP90_R07N3
+    BTaggingWP50_R07N4
+    BTaggingWP70_R07N4
+    BTaggingWP90_R07N4
+    BTaggingWP50_R07N5
+    BTaggingWP70_R07N5
+    BTaggingWP90_R07N5
+    BTaggingWP50_R07N6
+    BTaggingWP70_R07N6
+    BTaggingWP90_R07N6
+    BTaggingWP50_R10N2
+    BTaggingWP70_R10N2
+    BTaggingWP90_R10N2
+    BTaggingWP50_R10N3
+    BTaggingWP70_R10N3
+    BTaggingWP90_R10N3
+    BTaggingWP50_R10N4
+    BTaggingWP70_R10N4
+    BTaggingWP90_R10N4
+    BTaggingWP50_R10N5
+    BTaggingWP70_R10N5
+    BTaggingWP90_R10N5
+    BTaggingWP50_R10N6
+    BTaggingWP70_R10N6
+    BTaggingWP90_R10N6
+    BTaggingWP50_R12N2
+    BTaggingWP70_R12N2
+    BTaggingWP90_R12N2
+    BTaggingWP50_R12N3
+    BTaggingWP70_R12N3
+    BTaggingWP90_R12N3
+    BTaggingWP50_R12N4
+    BTaggingWP70_R12N4
+    BTaggingWP90_R12N4
+    BTaggingWP50_R12N5
+    BTaggingWP70_R12N5
+    BTaggingWP90_R12N5
+    BTaggingWP50_R12N6
+    BTaggingWP70_R12N6
+    BTaggingWP90_R12N6
+    BTaggingWP50_R15N2
+    BTaggingWP70_R15N2
+    BTaggingWP90_R15N2
+    BTaggingWP50_R15N3
+    BTaggingWP70_R15N3
+    BTaggingWP90_R15N3
+    BTaggingWP50_R15N4
+    BTaggingWP70_R15N4
+    BTaggingWP90_R15N4
+    BTaggingWP50_R15N5
+    BTaggingWP70_R15N5
+    BTaggingWP90_R15N5
+    BTaggingWP50_R15N6
+    BTaggingWP70_R15N6
+    BTaggingWP90_R15N6
     BTaggingWP50_R05_inclusive
     BTaggingWP70_R05_inclusive
     BTaggingWP90_R05_inclusive
@@ -257,7 +292,97 @@ set ExecutionPath {
     BTaggingWP70_R15_inclusive
     BTaggingWP90_R15_inclusive
 
-    
+    BTagging_JER_WP50_R05N2
+    BTagging_JER_WP70_R05N2
+    BTagging_JER_WP90_R05N2
+    BTagging_JER_WP50_R05N3
+    BTagging_JER_WP70_R05N3
+    BTagging_JER_WP90_R05N3
+    BTagging_JER_WP50_R05N4
+    BTagging_JER_WP70_R05N4
+    BTagging_JER_WP90_R05N4
+    BTagging_JER_WP50_R05N5
+    BTagging_JER_WP70_R05N5
+    BTagging_JER_WP90_R05N5
+    BTagging_JER_WP50_R05N6
+    BTagging_JER_WP70_R05N6
+    BTagging_JER_WP90_R05N6
+    BTagging_JER_WP50_R07N2
+    BTagging_JER_WP70_R07N2
+    BTagging_JER_WP90_R07N2
+    BTagging_JER_WP50_R07N3
+    BTagging_JER_WP70_R07N3
+    BTagging_JER_WP90_R07N3
+    BTagging_JER_WP50_R07N4
+    BTagging_JER_WP70_R07N4
+    BTagging_JER_WP90_R07N4
+    BTagging_JER_WP50_R07N5
+    BTagging_JER_WP70_R07N5
+    BTagging_JER_WP90_R07N5
+    BTagging_JER_WP50_R07N6
+    BTagging_JER_WP70_R07N6
+    BTagging_JER_WP90_R07N6
+    BTagging_JER_WP50_R10N2
+    BTagging_JER_WP70_R10N2
+    BTagging_JER_WP90_R10N2
+    BTagging_JER_WP50_R10N3
+    BTagging_JER_WP70_R10N3
+    BTagging_JER_WP90_R10N3
+    BTagging_JER_WP50_R10N4
+    BTagging_JER_WP70_R10N4
+    BTagging_JER_WP90_R10N4
+    BTagging_JER_WP50_R10N5
+    BTagging_JER_WP70_R10N5
+    BTagging_JER_WP90_R10N5
+    BTagging_JER_WP50_R10N6
+    BTagging_JER_WP70_R10N6
+    BTagging_JER_WP90_R10N6
+    BTagging_JER_WP50_R12N2
+    BTagging_JER_WP70_R12N2
+    BTagging_JER_WP90_R12N2
+    BTagging_JER_WP50_R12N3
+    BTagging_JER_WP70_R12N3
+    BTagging_JER_WP90_R12N3
+    BTagging_JER_WP50_R12N4
+    BTagging_JER_WP70_R12N4
+    BTagging_JER_WP90_R12N4
+    BTagging_JER_WP50_R12N5
+    BTagging_JER_WP70_R12N5
+    BTagging_JER_WP90_R12N5
+    BTagging_JER_WP50_R12N6
+    BTagging_JER_WP70_R12N6
+    BTagging_JER_WP90_R12N6
+    BTagging_JER_WP50_R15N2
+    BTagging_JER_WP70_R15N2
+    BTagging_JER_WP90_R15N2
+    BTagging_JER_WP50_R15N3
+    BTagging_JER_WP70_R15N3
+    BTagging_JER_WP90_R15N3
+    BTagging_JER_WP50_R15N4
+    BTagging_JER_WP70_R15N4
+    BTagging_JER_WP90_R15N4
+    BTagging_JER_WP50_R15N5
+    BTagging_JER_WP70_R15N5
+    BTagging_JER_WP90_R15N5
+    BTagging_JER_WP50_R15N6
+    BTagging_JER_WP70_R15N6
+    BTagging_JER_WP90_R15N6
+    BTagging_JER_WP50_R05_inclusive
+    BTagging_JER_WP70_R05_inclusive
+    BTagging_JER_WP90_R05_inclusive
+    BTagging_JER_WP50_R07_inclusive
+    BTagging_JER_WP70_R07_inclusive
+    BTagging_JER_WP90_R07_inclusive
+    BTagging_JER_WP50_R10_inclusive
+    BTagging_JER_WP70_R10_inclusive
+    BTagging_JER_WP90_R10_inclusive
+    BTagging_JER_WP50_R12_inclusive
+    BTagging_JER_WP70_R12_inclusive
+    BTagging_JER_WP90_R12_inclusive
+    BTagging_JER_WP50_R15_inclusive
+    BTagging_JER_WP70_R15_inclusive
+    BTagging_JER_WP90_R15_inclusive
+     
     TauTagging_R05N2
     TauTagging_R05N3
     TauTagging_R05N4
@@ -283,13 +408,42 @@ set ExecutionPath {
     TauTagging_R15N4
     TauTagging_R15N5
     TauTagging_R15N6
-
     TauTagging_R05_inclusive
     TauTagging_R07_inclusive
     TauTagging_R10_inclusive
     TauTagging_R12_inclusive
     TauTagging_R15_inclusive
 
+    TauTagging_JER_R05N2
+    TauTagging_JER_R05N3
+    TauTagging_JER_R05N4
+    TauTagging_JER_R05N5
+    TauTagging_JER_R05N6
+    TauTagging_JER_R07N2
+    TauTagging_JER_R07N3
+    TauTagging_JER_R07N4
+    TauTagging_JER_R07N5
+    TauTagging_JER_R07N6
+    TauTagging_JER_R10N2
+    TauTagging_JER_R10N3
+    TauTagging_JER_R10N4
+    TauTagging_JER_R10N5
+    TauTagging_JER_R10N6
+    TauTagging_JER_R12N2
+    TauTagging_JER_R12N3
+    TauTagging_JER_R12N4
+    TauTagging_JER_R12N5
+    TauTagging_JER_R12N6
+    TauTagging_JER_R15N2
+    TauTagging_JER_R15N3
+    TauTagging_JER_R15N4
+    TauTagging_JER_R15N5
+    TauTagging_JER_R15N6
+    TauTagging_JER_R05_inclusive
+    TauTagging_JER_R07_inclusive
+    TauTagging_JER_R10_inclusive
+    TauTagging_JER_R12_inclusive
+    TauTagging_JER_R15_inclusive
 
 
     ScalarHT
@@ -1010,6 +1164,7 @@ source CLIC/CLICdet_JetSmearing.tcl
 ########################
 
 source  CLIC/CLICdet_JetFlavorAssociation.tcl
+source  CLIC/CLICdet_JetFlavorAssociation_JER.tcl
 
 ###########
 # b-tagging
@@ -1017,6 +1172,7 @@ source  CLIC/CLICdet_JetFlavorAssociation.tcl
 # based on CLICdp-Note-2014-002    
 
 source  CLIC/CLICdet_BTagging.tcl
+source  CLIC/CLICdet_BTagging_JER.tcl
 
 
 #############
@@ -1025,6 +1181,7 @@ source  CLIC/CLICdet_BTagging.tcl
 # based on LCD-2010-009
 
 source CLIC/CLICdet_TauTagging.tcl
+source CLIC/CLICdet_TauTagging_JER.tcl
 
 
 

--- a/cards/delphes_card_CLICdet_Stage3.tcl
+++ b/cards/delphes_card_CLICdet_Stage3.tcl
@@ -760,7 +760,6 @@ module Isolation PhotonIsolation {
 
 module Efficiency ElectronEfficiency {
     set InputArray ElectronFilter/electrons
-    #set InputArray ElectronDressing/electrons
     set OutputArray electrons
 
     # set EfficiencyFormula {efficiency formula as a function of eta and pt}


### PR DESCRIPTION
Hi,
I have slightly modified the isolation criteria in the CLICdet cards to be more adapted to the CLIC environment. In addition, flavor tagging is added for the smeared jets mimicking the effect of beam-induced background.
Thanks,
Ulrike