### PR TITLE
Radius and particle-density dependence of formula parameterisations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,7 @@ tmp/modules/ModulesDict.$(SrcSuf): \
 	modules/VertexFinder.h \
 	modules/VertexFinderDA4D.h \
 	modules/DecayFilter.h \
+	modules/ParticleDensity.h \
 	modules/ExampleModule.h
 tmp/modules/ModulesDict$(PcmSuf): \
 	tmp/modules/ModulesDict.$(SrcSuf)
@@ -509,7 +510,8 @@ tmp/classes/DelphesFactory.$(ObjSuf): \
 	external/ExRootAnalysis/ExRootTreeBranch.h
 tmp/classes/DelphesFormula.$(ObjSuf): \
 	classes/DelphesFormula.$(SrcSuf) \
-	classes/DelphesFormula.h
+	classes/DelphesFormula.h \
+	classes/DelphesClasses.h
 tmp/classes/DelphesHepMCReader.$(ObjSuf): \
 	classes/DelphesHepMCReader.$(SrcSuf) \
 	classes/DelphesHepMCReader.h \
@@ -880,6 +882,15 @@ tmp/modules/OldCalorimeter.$(ObjSuf): \
 	external/ExRootAnalysis/ExRootClassifier.h \
 	external/ExRootAnalysis/ExRootFilter.h \
 	external/ExRootAnalysis/ExRootResult.h
+tmp/modules/ParticleDensity.$(ObjSuf): \
+	modules/ParticleDensity.$(SrcSuf) \
+	modules/ParticleDensity.h \
+	classes/DelphesClasses.h \
+	classes/DelphesFactory.h \
+	classes/DelphesFormula.h \
+	external/ExRootAnalysis/ExRootClassifier.h \
+	external/ExRootAnalysis/ExRootFilter.h \
+	external/ExRootAnalysis/ExRootResult.h
 tmp/modules/ParticlePropagator.$(ObjSuf): \
 	modules/ParticlePropagator.$(SrcSuf) \
 	modules/ParticlePropagator.h \
@@ -1016,7 +1027,9 @@ tmp/modules/TrackCovariance.$(ObjSuf): \
 	modules/TrackCovariance.$(SrcSuf) \
 	modules/TrackCovariance.h \
 	classes/DelphesClasses.h \
-	external/TrackCovariance/SolGeom.h
+	external/TrackCovariance/SolGeom.h \
+	external/TrackCovariance/SolGridCov.h \
+	external/TrackCovariance/ObsTrk.h
 tmp/modules/TrackPileUpSubtractor.$(ObjSuf): \
 	modules/TrackPileUpSubtractor.$(SrcSuf) \
 	modules/TrackPileUpSubtractor.h \
@@ -1173,6 +1186,7 @@ DELPHES_OBJ +=  \
 	tmp/modules/Merger.$(ObjSuf) \
 	tmp/modules/MomentumSmearing.$(ObjSuf) \
 	tmp/modules/OldCalorimeter.$(ObjSuf) \
+	tmp/modules/ParticleDensity.$(ObjSuf) \
 	tmp/modules/ParticlePropagator.$(ObjSuf) \
 	tmp/modules/PdgCodeFilter.$(ObjSuf) \
 	tmp/modules/PhotonConversions.$(ObjSuf) \
@@ -2259,6 +2273,10 @@ external/fastjet/internal/Dnn3piCylinder.hh: \
 
 external/fastjet/AreaDefinition.hh: \
 	external/fastjet/GhostedAreaSpec.hh
+	@touch $@
+
+modules/ParticleDensity.h: \
+	classes/DelphesModule.h
 	@touch $@
 
 modules/TimeSmearing.h: \

--- a/classes/DelphesClasses.cc
+++ b/classes/DelphesClasses.cc
@@ -171,6 +171,7 @@ Candidate::Candidate() :
   ExclYmerge34(0),
   ExclYmerge45(0),
   ExclYmerge56(0),
+  ParticleDensity(0),
   fFactory(0),
   fArray(0)
 {

--- a/classes/DelphesClasses.h
+++ b/classes/DelphesClasses.h
@@ -732,6 +732,9 @@ public:
   Double_t ExclYmerge45;
   Double_t ExclYmerge56;
 
+  // event characteristics variables
+  Double_t ParticleDensity; // particle multiplicity density in the proximity of the particle
+  
   static CompBase *fgCompare; //!
   const CompBase *GetCompare() const { return fgCompare; }
 

--- a/classes/DelphesFormula.cc
+++ b/classes/DelphesFormula.cc
@@ -17,6 +17,7 @@
  */
 
 #include "classes/DelphesFormula.h"
+#include "classes/DelphesClasses.h"
 
 #include "TString.h"
 
@@ -62,6 +63,7 @@ Int_t DelphesFormula::Compile(const char *expression)
   buffer.ReplaceAll("d0", "[0]");
   buffer.ReplaceAll("dz", "[1]");
   buffer.ReplaceAll("ctgTheta", "[2]");
+  buffer.ReplaceAll("radius", "[3]");
 
 #if ROOT_VERSION_CODE < ROOT_VERSION(6, 3, 0)
   TFormula::SetMaxima(100000, 1000, 1000000);
@@ -76,12 +78,19 @@ Int_t DelphesFormula::Compile(const char *expression)
 
 //------------------------------------------------------------------------------
 
-Double_t DelphesFormula::Eval(Double_t pt, Double_t eta, Double_t phi,
-  Double_t energy, Double_t d0, Double_t dz,
-  Double_t ctgTheta)
+Double_t DelphesFormula::Eval(Double_t pt, Double_t eta, Double_t phi, Double_t energy, Candidate *candidate)
 {
+
+  Double_t d0 = 0., dz = 0., ctgTheta = 0., radius = 0.;
+  if (candidate) {
+    d0 = candidate->D0;
+    dz = candidate->DZ;
+    ctgTheta = candidate->CtgTheta;
+    radius = candidate->Position.Pt();
+  }
+    
   Double_t x[4] = {pt, eta, phi, energy};
-  Double_t params[3] = {d0, dz, ctgTheta};
+  Double_t params[4] = {d0, dz, ctgTheta, radius};
   return EvalPar(x, params);
 }
 

--- a/classes/DelphesFormula.cc
+++ b/classes/DelphesFormula.cc
@@ -64,6 +64,7 @@ Int_t DelphesFormula::Compile(const char *expression)
   buffer.ReplaceAll("dz", "[1]");
   buffer.ReplaceAll("ctgTheta", "[2]");
   buffer.ReplaceAll("radius", "[3]");
+  buffer.ReplaceAll("density", "[4]");
 
 #if ROOT_VERSION_CODE < ROOT_VERSION(6, 3, 0)
   TFormula::SetMaxima(100000, 1000, 1000000);
@@ -81,16 +82,17 @@ Int_t DelphesFormula::Compile(const char *expression)
 Double_t DelphesFormula::Eval(Double_t pt, Double_t eta, Double_t phi, Double_t energy, Candidate *candidate)
 {
 
-  Double_t d0 = 0., dz = 0., ctgTheta = 0., radius = 0.;
+  Double_t d0 = 0., dz = 0., ctgTheta = 0., radius = 0., density = 0.;
   if (candidate) {
     d0 = candidate->D0;
     dz = candidate->DZ;
     ctgTheta = candidate->CtgTheta;
     radius = candidate->Position.Pt();
+    density = candidate->ParticleDensity;
   }
     
   Double_t x[4] = {pt, eta, phi, energy};
-  Double_t params[4] = {d0, dz, ctgTheta, radius};
+  Double_t params[5] = {d0, dz, ctgTheta, radius, density};
   return EvalPar(x, params);
 }
 

--- a/classes/DelphesFormula.h
+++ b/classes/DelphesFormula.h
@@ -21,6 +21,8 @@
 
 #include "TFormula.h"
 
+class Candidate;
+
 class DelphesFormula: public TFormula
 {
 public:
@@ -32,9 +34,7 @@ public:
 
   Int_t Compile(const char *expression);
 
-  Double_t Eval(Double_t pt, Double_t eta = 0, Double_t phi = 0,
-    Double_t energy = 0, Double_t d0 = 0, Double_t dz = 0,
-    Double_t ctgTheta = 0);
+  Double_t Eval(Double_t pt, Double_t eta = 0, Double_t phi = 0, Double_t energy = 0, Candidate *candidate = nullptr);
 };
 
 #endif /* DelphesFormula_h */

--- a/modules/AngularSmearing.cc
+++ b/modules/AngularSmearing.cc
@@ -111,8 +111,8 @@ void AngularSmearing::Process()
 
     // apply smearing formula for eta,phi
 
-    eta = gRandom->Gaus(eta, fFormulaEta->Eval(pt, eta, phi, e));
-    phi = gRandom->Gaus(phi, fFormulaPhi->Eval(pt, eta, phi, e));
+    eta = gRandom->Gaus(eta, fFormulaEta->Eval(pt, eta, phi, e, candidate));
+    phi = gRandom->Gaus(phi, fFormulaPhi->Eval(pt, eta, phi, e, candidate));
 
     if(pt <= 0.0) continue;
 

--- a/modules/Efficiency.cc
+++ b/modules/Efficiency.cc
@@ -94,7 +94,7 @@ void Efficiency::Finish()
 void Efficiency::Process()
 {
   Candidate *candidate;
-  Double_t pt, eta, phi, e, d0, dz, ctgTheta;
+  Double_t pt, eta, phi, e;
 
   fItInputArray->Reset();
   while((candidate = static_cast<Candidate *>(fItInputArray->Next())))
@@ -105,12 +105,9 @@ void Efficiency::Process()
     phi = candidatePosition.Phi();
     pt = candidateMomentum.Pt();
     e = candidateMomentum.E();
-    d0 = candidate->D0;
-    dz = candidate->DZ;
-    ctgTheta = candidate->CtgTheta;
-
+    
     // apply an efficency formula
-    if(gRandom->Uniform() > fFormula->Eval(pt, eta, phi, e, d0, dz, ctgTheta)) continue;
+    if(gRandom->Uniform() > fFormula->Eval(pt, eta, phi, e, candidate)) continue;
 
     fOutputArray->Add(candidate);
   }

--- a/modules/ModulesLinkDef.h
+++ b/modules/ModulesLinkDef.h
@@ -73,6 +73,7 @@
 #include "modules/VertexFinder.h"
 #include "modules/VertexFinderDA4D.h"
 #include "modules/DecayFilter.h"
+#include "modules/ParticleDensity.h"
 #include "modules/ExampleModule.h"
 
 #ifdef __CINT__
@@ -129,6 +130,7 @@
 #pragma link C++ class VertexFinder+;
 #pragma link C++ class VertexFinderDA4D+;
 #pragma link C++ class DecayFilter+;
+#pragma link C++ class ParticleDensity+;
 #pragma link C++ class ExampleModule+;
 
 #endif

--- a/modules/MomentumSmearing.cc
+++ b/modules/MomentumSmearing.cc
@@ -105,7 +105,7 @@ void MomentumSmearing::Process()
     phi = candidatePosition.Phi();
     pt = candidateMomentum.Pt();
     e = candidateMomentum.E();
-    res = fFormula->Eval(pt, eta, phi, e);
+    res = fFormula->Eval(pt, eta, phi, e, candidate);
 
     // apply smearing formula
     //pt = gRandom->Gaus(pt, fFormula->Eval(pt, eta, phi, e) * pt);

--- a/modules/ParticleDensity.cc
+++ b/modules/ParticleDensity.cc
@@ -1,0 +1,144 @@
+/*
+ *  Delphes: a framework for fast simulation of a generic collider experiment
+ *  Copyright (C) 2012-2014  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** \class ParticleDensity
+ *
+ *  This module calculates the particle multiplicity density in eta-phi bins.
+ *  It then assigns the value to the candidates according to the candidate eta.
+ *
+ *  \author R. Preghenella - INFN, Bologna
+ *
+ */
+
+#include "modules/ParticleDensity.h"
+
+#include "classes/DelphesClasses.h"
+#include "classes/DelphesFactory.h"
+#include "classes/DelphesFormula.h"
+
+#include "ExRootAnalysis/ExRootClassifier.h"
+#include "ExRootAnalysis/ExRootFilter.h"
+#include "ExRootAnalysis/ExRootResult.h"
+
+#include "TFormula.h"
+#include "TLorentzVector.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TRandom3.h"
+#include "TString.h"
+#include "TH2F.h"
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+using namespace std;
+
+//------------------------------------------------------------------------------
+
+ParticleDensity::ParticleDensity() :
+  fItInputArray(0)
+{}
+
+//------------------------------------------------------------------------------
+
+ParticleDensity::~ParticleDensity()
+{}
+
+//------------------------------------------------------------------------------
+
+void ParticleDensity::Init()
+{
+
+  // import input array(s)
+
+  fInputArray = ImportArray(GetString("InputArray", "FastJetFinder/jets"));
+  fItInputArray = fInputArray->MakeIterator();
+
+  // create output array(s)
+
+  fOutputArray = ExportArray(GetString("OutputArray", "tracks"));
+
+  // create multiplicity histogram
+
+  ExRootConfParam paramEta = GetParam("EtaBins");
+  const Long_t sizeEta = paramEta.GetSize();
+  Int_t nbinsEta = sizeEta - 1;
+  Float_t binsEta[sizeEta];
+  for (Int_t i = 0; i < sizeEta; ++i) {
+    binsEta[i] = paramEta[i].GetDouble();
+  }
+  
+  ExRootConfParam paramPhi = GetParam("PhiBins");
+  const Long_t sizePhi = paramPhi.GetSize();
+  Int_t nbinsPhi = sizePhi - 1;
+  Float_t binsPhi[sizePhi];
+  for (Int_t i = 0; i < sizePhi; ++i) {
+    binsPhi[i] = paramPhi[i].GetDouble();
+  }
+  
+  fHisto = new TH2F("hParticleDensity", ";#eta;#varphi;d^{2}N/d#etad#varphi", nbinsEta, binsEta, nbinsPhi, binsPhi);
+
+  fUseMomentumVector = GetBool("UseMomentumVector", false);
+}
+
+//------------------------------------------------------------------------------
+
+void ParticleDensity::Finish()
+{
+  if(fItInputArray) delete fItInputArray;
+  if (fHisto) delete fHisto;
+}
+
+//------------------------------------------------------------------------------
+
+void ParticleDensity::Process()
+{
+  Candidate *candidate;
+  fHisto->Reset();
+  
+  // loop over all input candidates to fill histogram
+  fItInputArray->Reset();
+  while((candidate = static_cast<Candidate *>(fItInputArray->Next()))) {
+    if (fUseMomentumVector) fHisto->Fill(candidate->Momentum.Eta(), candidate->Momentum.Phi());
+    else                    fHisto->Fill(candidate->Position.Eta(), candidate->Position.Phi());
+  }
+
+  // normalise by bin width
+  fHisto->Scale(1., "width");
+  
+  // loop over all input candidates to assign multiplicity
+  fItInputArray->Reset();
+  while((candidate = static_cast<Candidate *>(fItInputArray->Next()))) {
+    Int_t ieta, iphi;
+    if (fUseMomentumVector) {
+      ieta = fHisto->GetXaxis()->FindBin(candidate->Momentum.Eta());
+      iphi = fHisto->GetYaxis()->FindBin(candidate->Momentum.Phi());
+    } else {
+      ieta = fHisto->GetXaxis()->FindBin(candidate->Position.Eta());
+      iphi = fHisto->GetYaxis()->FindBin(candidate->Position.Phi());
+    }
+    candidate->ParticleDensity = fHisto->GetBinContent(ieta, iphi);
+    fOutputArray->Add(candidate);
+  }
+
+  
+}
+
+//------------------------------------------------------------------------------

--- a/modules/ParticleDensity.h
+++ b/modules/ParticleDensity.h
@@ -1,0 +1,62 @@
+/*
+ *  Delphes: a framework for fast simulation of a generic collider experiment
+ *  Copyright (C) 2012-2014  Universite catholique de Louvain (UCL), Belgium
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ParticleDensity_h
+#define ParticleDensity_h
+
+/** \class ParticleDensity
+ *
+ *  This module calculates the particle multiplicity density in eta-phi bins.
+ *  It then assigns the value to the candidates according to the candidate eta.
+ *
+ *  \author R. Preghenella - INFN, Bologna
+ *
+ */
+
+#include "classes/DelphesModule.h"
+
+#include <deque>
+
+class TObjArray;
+class TH2F;
+
+class ParticleDensity: public DelphesModule
+{
+public:
+  ParticleDensity();
+  ~ParticleDensity();
+
+  void Init();
+  void Process();
+  void Finish();
+
+private:
+
+  TIterator *fItInputArray; //!
+
+  const TObjArray *fInputArray; //!
+
+  TObjArray *fOutputArray; //!
+
+  Bool_t fUseMomentumVector; // !
+  TH2F *fHisto; //!
+  
+  ClassDef(ParticleDensity, 1)
+};
+
+#endif

--- a/modules/TrackSmearing.cc
+++ b/modules/TrackSmearing.cc
@@ -157,7 +157,7 @@ void TrackSmearing::Process()
   Int_t iCandidate = 0;
   TLorentzVector beamSpotPosition;
   Candidate *candidate, *mother;
-  Double_t pt, eta, d0, d0Error, trueD0, dz, dzError, trueDZ, p, pError, trueP, ctgTheta, ctgThetaError, trueCtgTheta, phi, phiError, truePhi;
+  Double_t pt, eta, e, d0, d0Error, trueD0, dz, dzError, trueDZ, p, pError, trueP, ctgTheta, ctgThetaError, trueCtgTheta, phi, phiError, truePhi;
   Double_t x, y, z, t, px, py, pz, theta;
   Double_t q, r;
   Double_t x_c, y_c, r_c, phi_0;
@@ -222,7 +222,8 @@ void TrackSmearing::Process()
 
     pt = momentum.Pt();
     eta = momentum.Eta();
-
+    e = momentum.E();
+    
     d0 = trueD0 = candidate->D0;
     dz = trueDZ = candidate->DZ;
 
@@ -231,7 +232,7 @@ void TrackSmearing::Process()
     phi = truePhi = candidate->Phi;
 
     if(fUseD0Formula)
-      d0Error = fD0Formula->Eval(pt, eta);
+      d0Error = fD0Formula->Eval(pt, eta, phi, e, candidate);
     else
     {
       Int_t xbin, ybin;
@@ -246,7 +247,7 @@ void TrackSmearing::Process()
       continue;
 
     if(fUseDZFormula)
-      dzError = fDZFormula->Eval(pt, eta);
+      dzError = fDZFormula->Eval(pt, eta, phi, e, candidate);
     else
     {
       Int_t xbin, ybin;
@@ -261,7 +262,7 @@ void TrackSmearing::Process()
       continue;
 
     if(fUsePFormula)
-      pError = fPFormula->Eval(pt, eta) * p;
+      pError = fPFormula->Eval(pt, eta, phi, e, candidate) * p;
     else
     {
       Int_t xbin, ybin;
@@ -276,7 +277,7 @@ void TrackSmearing::Process()
       continue;
 
     if(fUseCtgThetaFormula)
-      ctgThetaError = fCtgThetaFormula->Eval(pt, eta);
+      ctgThetaError = fCtgThetaFormula->Eval(pt, eta, phi, e, candidate);
     else
     {
       Int_t xbin, ybin;
@@ -291,7 +292,7 @@ void TrackSmearing::Process()
       continue;
 
     if(fUsePhiFormula)
-      phiError = fPhiFormula->Eval(pt, eta);
+      phiError = fPhiFormula->Eval(pt, eta, phi, e, candidate);
     else
     {
       Int_t xbin, ybin;


### PR DESCRIPTION
The commits in this PR provide the possibility of defining parameterisation formulas that depend on the position of the particle vertex wrt. beam line (radius) and on the particle-multiplicity density.

The DelphesFormula::Eval function is redefined to allow one to include future parameters for parameterisations that can be taken from Candidates in a generalised way.

A new module is added that computes the particle density in a eta-phi grid sets the ParticleDensity value of the candidate, to be used in formula parameterisations.
