### PR TITLE
IdentificationMap: Alter the PID variable of candidate clones rather than the original candidates

### DIFF
--- a/modules/IdentificationMap.cc
+++ b/modules/IdentificationMap.cc
@@ -169,6 +169,7 @@ void IdentificationMap::Process()
       if(total <= r && r < total + p)
       {
         // change PID of particle
+        candidate = static_cast<Candidate *>(candidate->Clone());
         if(pdgCodeOut != 0) candidate->PID = charge * pdgCodeOut;
         fOutputArray->Add(candidate);
         break;


### PR DESCRIPTION
Currently, if a particle is accepted for mapping onto a new particle ID (PID), the original copy of the candidate (which might be owned by a module upstream of the IdentificationMap instance) is altered. This may have unintended consequences. For example, what if the intent is not to alter the original particle, but rather to create a new list of particles with alternate PID settings? If one alters the original candidate's PID setting, then after-the-fact it's not possible to compare how the PID algorithm performed (e.g. you lose the ability to do efficiency and mis-identification studies to cross-check the implementation of the IdentificaionMap in the first place). 

This change clones the candidate before then altering its PID variable and storing it in the output list.