### PR TITLE
Temporary fix UserHooks API changed in Pythia 8.3 series

### DIFF
--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -295,12 +295,14 @@ int main(int argc, char *argv[])
     pythia = new Pythia8::Pythia;
 
     // jet matching
+#if PYTHIA_VERSION_INTEGER < 8300
     matching = combined->getHook(*pythia);
     if(!matching)
     {
       throw runtime_error("can't do matching");
     }
     pythia->setUserHooksPtr(matching);
+#endif
 
     if(pythia == NULL)
     {


### PR DESCRIPTION
The API in the upcoming Pythia 8.3 series has changed and the use of user hooks should be modified.
This PR brings a temporary fix to be able to build Delphes with Pythia 8.3.