### PR TITLE
CLICdet: correction to configuration of FastJetFinderKt

### DIFF
--- a/cards/delphes_card_CLICdet_Stage1.tcl
+++ b/cards/delphes_card_CLICdet_Stage1.tcl
@@ -944,7 +944,7 @@ module Merger GenMissingET {
 
 module FastJetFinder FastJetFinderKt {
     #  set InputArray Calorimeter/towers
-    set InputArray EFlowMerger/eflow
+    set InputArray EFlowFilter/eflow
 
     set OutputArray KTjets
 

--- a/cards/delphes_card_CLICdet_Stage2.tcl
+++ b/cards/delphes_card_CLICdet_Stage2.tcl
@@ -1135,7 +1135,7 @@ module Merger GenMissingET {
 
 module FastJetFinder FastJetFinderKt {
     #  set InputArray Calorimeter/towers
-    set InputArray EFlowMerger/eflow
+    set InputArray EFlowFilter/eflow
 
     set OutputArray KTjets
 

--- a/cards/delphes_card_CLICdet_Stage3.tcl
+++ b/cards/delphes_card_CLICdet_Stage3.tcl
@@ -1131,7 +1131,7 @@ module Merger GenMissingET {
 
 module FastJetFinder FastJetFinderKt {
     #  set InputArray Calorimeter/towers
-    set InputArray EFlowMerger/eflow
+    set InputArray EFlowFilter/eflow
 
     set OutputArray KTjets
 

--- a/cards/delphes_card_CLICdet_Stage3_fcal.tcl
+++ b/cards/delphes_card_CLICdet_Stage3_fcal.tcl
@@ -1283,7 +1283,7 @@ module Merger GenMissingET {
 
 module FastJetFinder FastJetFinderKt {
     #  set InputArray Calorimeter/towers
-    set InputArray EFlowMerger/eflow
+    set InputArray EFlowFilter/eflow
 
     set OutputArray KTjets
 


### PR DESCRIPTION
Input collection changed for inclusive Kt clustering, for all CLICdet models.
EFlowFilter output is now used, instead of EFlowMerger output collection used previously.
This change removes reconstructed isolated objects (electrons, muons, photons) from clustering.
