### PR TITLE
Possible fix for TFormula related issue with ROOT >= 6.23/00

### DIFF
--- a/classes/DelphesTF2.cc
+++ b/classes/DelphesTF2.cc
@@ -31,7 +31,9 @@ DelphesTF2::DelphesTF2() :
   TF2()
 {
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 3, 0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 23, 0)
+  fFormula = std::unique_ptr<TFormula>(new TFormula());
+#elif ROOT_VERSION_CODE >= ROOT_VERSION(6, 3, 0)
   fFormula = new TFormula();
 #endif
 }


### PR DESCRIPTION
The change https://github.com/root-project/root/pull/7035 pushed yesterday (Jan 19th, 2021) in the ROOT HEAD broke the LCG delphes builds. The small PR provides a possible fix.