### PR TITLE
DelphesTF2: TF2 changes were backported to root 6.22.08

### DIFF
--- a/classes/DelphesTF2.cc
+++ b/classes/DelphesTF2.cc
@@ -31,7 +31,7 @@ DelphesTF2::DelphesTF2() :
   TF2()
 {
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 23, 0)
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 7)
   fFormula = std::unique_ptr<TFormula>(new TFormula());
 #elif ROOT_VERSION_CODE >= ROOT_VERSION(6, 3, 0)
   fFormula = new TFormula();


### PR DESCRIPTION
This change made it to the root 6.22 release branch, so with this check delphes should also compile against these newer releases and the current root 6.22-patches branch.

/cc @gganis 