### PR TITLE
[readme] Use zenodo DOI pointing to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/delphes/delphes/actions/workflows/ci.yml/badge.svg)](https://github.com/delphes/delphes/actions/workflows/ci.yml) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3735069.svg)](https://doi.org/10.5281/zenodo.3735069)
+[![CI](https://github.com/delphes/delphes/actions/workflows/ci.yml/badge.svg)](https://github.com/delphes/delphes/actions/workflows/ci.yml) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.821635.svg)](https://doi.org/10.5281/zenodo.821635)
 
 Delphes
 =======


### PR DESCRIPTION
Just saw that the current badge points to the DOI for v3.4.3pre01. In order not to have to update it manually, Zenodo also creates a DOI that always points to the latest release, which I propose to add here.