### PR TITLE
Add set/getter for TTree to ExRootTreeWriter

### DIFF
--- a/external/ExRootAnalysis/ExRootTreeWriter.h
+++ b/external/ExRootAnalysis/ExRootTreeWriter.h
@@ -27,6 +27,9 @@ public:
   void SetTreeFile(TFile *file) { fFile = file; }
   void SetTreeName(const char *name) { fTreeName = name; }
 
+  TTree* GetTree() { return fTree; }
+  void SetTree(TTree* t) { fTree = t; }
+
   ExRootTreeBranch *NewBranch(const char *name, TClass *cl);
   void AddInfo(const char *name, Double_t value);
 


### PR DESCRIPTION
With these two small functions it becomes possible to access the TTree that is used by the ExRootTreeWriter. For the nominal usage inside Delphes nothing changes. However, it becomes possible to use the contents of the TTree that is filled by the ExRootTreeWriter, without having to write an output file first and then reading that again.

E.g. we use this in [key4hep/k4SimDelphes](https://github.com/key4hep/k4SimDelphes/) to convert the contents of the TTree directly. What we do there is to create an `ExRootTreeWriter` without an output file and then setting a TTree without a connection to a TFile:

```cpp
treeWriter = new ExRootTreeWriter(nullptr, "Delphes");
auto* tree = new TTree("DelphesTree", "Analysis");
treeWriter->SetTree(tree);
modularDelphes->SetTreeWriter(treeWriter);
// from here on we can use Delphes to run the simulation

// if we want to use the contents of the TTree we simply do
auto* delphesTree = treeWriter->GetTree(); 
// hypotethical process function that runs directly on the TTree without creating an output file
process(delphesTree);
```

In this way we can use the full power of Delphes, and are able to convert the output of Delphes into our format on the fly. We would be very glad if these changes could be added to Delphes itself, which would make it possible for us to remove the copy of `ExRootTreeWriter.h` that we currently have to ship and maintain (and which has since already gone out of date as I have just realized).