### PR TITLE
Rdev fix relocation

### DIFF
--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -9,10 +9,10 @@ file(GLOB headers *.h)
 list(REMOVE_ITEM headers ${CMAKE_CURRENT_SOURCE_DIR}/ClassesLinkDef.h)
 
 DELPHES_GENERATE_DICTIONARY(ClassesDict 
-  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesModule.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesFactory.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/SortableObject.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesClasses.h
+  classes/DelphesModule.h
+  classes/DelphesFactory.h
+  classes/SortableObject.h
+  classes/DelphesClasses.h
   LINKDEF ClassesLinkDef.h
 )
 

--- a/classes/CMakeLists.txt
+++ b/classes/CMakeLists.txt
@@ -8,13 +8,25 @@ file(GLOB sources *.cc)
 file(GLOB headers *.h)
 list(REMOVE_ITEM headers ${CMAKE_CURRENT_SOURCE_DIR}/ClassesLinkDef.h)
 
-DELPHES_GENERATE_DICTIONARY(ClassesDict 
-  classes/DelphesModule.h
-  classes/DelphesFactory.h
-  classes/SortableObject.h
-  classes/DelphesClasses.h
-  LINKDEF ClassesLinkDef.h
-)
+# the macro invocation for ROOT6 ensures that the headers are relocatable
+if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
+  DELPHES_GENERATE_DICTIONARY(ClassesDict 
+    classes/DelphesModule.h
+    classes/DelphesFactory.h
+    classes/SortableObject.h
+    classes/DelphesClasses.h
+    LINKDEF ClassesLinkDef.h
+  )
+else()
+  # for ROOT5 the above fails, keep the following as workaround
+  DELPHES_GENERATE_DICTIONARY(ClassesDict
+  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesModule.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesFactory.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/SortableObject.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/DelphesClasses.h
+    LINKDEF ClassesLinkDef.h
+  )
+endif()
 
 add_library(classes OBJECT ${sources} ClassesDict.cxx)
 

--- a/external/ExRootAnalysis/CMakeLists.txt
+++ b/external/ExRootAnalysis/CMakeLists.txt
@@ -5,9 +5,21 @@ include_directories(
 
 file(GLOB sources *.cc)
 file(GLOB headers *.h)
+
 list(REMOVE_ITEM headers ${CMAKE_CURRENT_SOURCE_DIR}/ExRootAnalysisLinkDef.h)
 
-DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict ${headers} LINKDEF ExRootAnalysisLinkDef.h)
+DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict
+  ExRootAnalysis/ExRootClassifier.h
+  ExRootAnalysis/ExRootConfReader.h
+  ExRootAnalysis/ExRootFilter.h
+  ExRootAnalysis/ExRootProgressBar.h
+  ExRootAnalysis/ExRootResult.h
+  ExRootAnalysis/ExRootTask.h
+  ExRootAnalysis/ExRootTreeBranch.h
+  ExRootAnalysis/ExRootTreeReader.h
+  ExRootAnalysis/ExRootTreeWriter.h
+  ExRootAnalysis/ExRootUtilities.h
+  LINKDEF ExRootAnalysisLinkDef.h)
 
 add_library(ExRootAnalysis OBJECT ${sources} ExRootAnalysisDict.cxx)
 

--- a/external/ExRootAnalysis/CMakeLists.txt
+++ b/external/ExRootAnalysis/CMakeLists.txt
@@ -8,18 +8,24 @@ file(GLOB headers *.h)
 
 list(REMOVE_ITEM headers ${CMAKE_CURRENT_SOURCE_DIR}/ExRootAnalysisLinkDef.h)
 
-DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict
-  ExRootAnalysis/ExRootClassifier.h
-  ExRootAnalysis/ExRootConfReader.h
-  ExRootAnalysis/ExRootFilter.h
-  ExRootAnalysis/ExRootProgressBar.h
-  ExRootAnalysis/ExRootResult.h
-  ExRootAnalysis/ExRootTask.h
-  ExRootAnalysis/ExRootTreeBranch.h
-  ExRootAnalysis/ExRootTreeReader.h
-  ExRootAnalysis/ExRootTreeWriter.h
-  ExRootAnalysis/ExRootUtilities.h
-  LINKDEF ExRootAnalysisLinkDef.h)
+# the macro invocation for ROOT6 ensures that the headers are relocatable
+if (NOT ${ROOT_VERSION} VERSION_LESS "6.0.0")
+  DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict
+    ExRootAnalysis/ExRootClassifier.h
+    ExRootAnalysis/ExRootConfReader.h
+    ExRootAnalysis/ExRootFilter.h
+    ExRootAnalysis/ExRootProgressBar.h
+    ExRootAnalysis/ExRootResult.h
+    ExRootAnalysis/ExRootTask.h
+    ExRootAnalysis/ExRootTreeBranch.h
+    ExRootAnalysis/ExRootTreeReader.h
+    ExRootAnalysis/ExRootTreeWriter.h
+    ExRootAnalysis/ExRootUtilities.h
+    LINKDEF ExRootAnalysisLinkDef.h)
+else()
+  # for ROOT5 the above fails, keep the following as workaround
+  DELPHES_GENERATE_DICTIONARY(ExRootAnalysisDict ${headers} LINKDEF ExRootAnalysisLinkDef.h)
+endif()
 
 add_library(ExRootAnalysis OBJECT ${sources} ExRootAnalysisDict.cxx)
 


### PR DESCRIPTION
Supersedes #79 

keeps the old cmake code for ROOTv5.