### PR TITLE
Fill Particle with correct pointer

### DIFF
--- a/modules/TreeWriter.cc
+++ b/modules/TreeWriter.cc
@@ -404,7 +404,7 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->C = candidate->C;
     entry->Mass = m;
 
-    //particle = static_cast<Candidate *>(candidate->GetCandidates()->At(0));
+    particle = static_cast<Candidate *>(candidate->GetCandidates()->At(0));
     //const TLorentzVector &initialPosition = particle->Position;
     const TLorentzVector &initialPosition = candidate->InitialPosition;
 
@@ -560,7 +560,7 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
     entry->C = candidate->C;
     entry->Mass = m;
 
-    //particle = static_cast<Candidate *>(candidate->GetCandidates()->At(0));
+    particle = static_cast<Candidate *>(candidate->GetCandidates()->At(0));
     //const TLorentzVector &initialPosition = particle->Position;
     const TLorentzVector &initialPosition = candidate->InitialPosition;
 


### PR DESCRIPTION
This was commented out in 0060caa. However, now the `Particle` associated to a `Track` or a `ParticleFlowCandidate` is no longer properly stored and there is no way to access it any longer from one of these. I am not sure if the initial change was by accident, or if it was intended, but it makes it impossible to access MC information from `Track`s or `ParticleFlowCandidate`s.

We discovered this in our converter, where the candidate matching is broken without this (see key4hep/k4SimDelphes#52).