### PR TITLE
Fix eventCounter/skipEvents bug in DelphesCMSFwlite

### DIFF
--- a/readers/DelphesCMSFWLite.cpp
+++ b/readers/DelphesCMSFWLite.cpp
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
 
       for(event.toBegin(); !event.atEnd() && !interrupted && (maxEvents <= 0 || eventCounter-skipEvents < maxEvents); ++event)
       {
-        if(eventCounter > skipEvents){
+        if(eventCounter >= skipEvents){
           ConvertInput(event, eventCounter, branchEvent, branchWeight, factory,
             allParticleOutputArray, stableParticleOutputArray, partonOutputArray, firstEvent);
           modularDelphes->ProcessTask();


### PR DESCRIPTION
Fixing a bug in the eventCounter/skipEvents.
The ">" comparison causes one more events to be skipped, e.g., the first event in case of the default value skipEvents=0.
(Note that the other readers increment eventCounter before the comparison and hence the ">" is correct in these cases.)