### PR TITLE
PdgCodeFilter update, for ghost-Hadron of jet constituents.

### DIFF
--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -785,7 +785,6 @@ module UniqueObjectFinder UniqueObjectFinder {
 module TreeWriter TreeWriter {
 # add Branch InputArray BranchName BranchClass
   add Branch Delphes/allParticles Particle GenParticle
-#  add Branch NeutrinoFilter/filteredParticles Particle2 GenParticle
 
   add Branch TrackMerger/tracks Track Track
   add Branch Calorimeter/towers Tower Tower

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -584,10 +584,13 @@ module Merger ScalarHT {
 
 module PdgCodeFilter NeutrinoFilter {
 
-  set InputArray Delphes/stableParticles
+  #set InputArray Delphes/stableParticles
+  set InputArray Delphes/allParticles
   set OutputArray filteredParticles
 
   set PTMin 0.0
+  set RequireStatus true
+  set RequireKeepGhostBHadron true
 
   add PdgCode {12}
   add PdgCode {14}
@@ -782,6 +785,7 @@ module UniqueObjectFinder UniqueObjectFinder {
 module TreeWriter TreeWriter {
 # add Branch InputArray BranchName BranchClass
   add Branch Delphes/allParticles Particle GenParticle
+#  add Branch NeutrinoFilter/filteredParticles Particle2 GenParticle
 
   add Branch TrackMerger/tracks Track Track
   add Branch Calorimeter/towers Tower Tower

--- a/cards/delphes_card_CMS.tcl
+++ b/cards/delphes_card_CMS.tcl
@@ -590,7 +590,7 @@ module PdgCodeFilter NeutrinoFilter {
 
   set PTMin 0.0
   set RequireStatus true
-  set RequireKeepGhostBHadron true
+  set RequireKeepGhostHadron true
 
   add PdgCode {12}
   add PdgCode {14}

--- a/modules/PdgCodeFilter.cc
+++ b/modules/PdgCodeFilter.cc
@@ -126,7 +126,6 @@ void PdgCodeFilter::Process()
   while((candidate = static_cast<Candidate *>(fItInputArray->Next())))
   {
     pdgCode = candidate->PID;
-    //std::cout << "--" << pdgCode << std::endl;
 
     if (fRequireKeepGhostBHadron) {
       if (isBHadron(abs(pdgCode)) ){

--- a/modules/PdgCodeFilter.cc
+++ b/modules/PdgCodeFilter.cc
@@ -85,7 +85,7 @@ void PdgCodeFilter::Init()
   fCharge = GetInt("Charge", 1);
 
   // keep bhadron
-  fRequireKeepGhostBHadron = GetBool("RequireKeepGhostBHadron", false);
+  fRequireKeepGhostHadron = GetBool("RequireKeepGhostHadron", false);
 
   // import input array
   fInputArray = ImportArray(GetString("InputArray", "Delphes/allParticles"));
@@ -127,8 +127,8 @@ void PdgCodeFilter::Process()
   {
     pdgCode = candidate->PID;
 
-    if (fRequireKeepGhostBHadron) {
-      if (isBHadron(abs(pdgCode)) ){
+    if (fRequireKeepGhostHadron) {
+      if (isBCSHadron(abs(pdgCode)) ){
         candidate->PT = candidate->PT * 1e-18;
         if (candidate->PT ==0) candidate->PT = 1e-18;
         candidate->Momentum.SetPtEtaPhiM(candidate->PT, candidate->Momentum.Eta(), candidate->Momentum.Phi(), candidate->Momentum.M());
@@ -153,7 +153,7 @@ void PdgCodeFilter::Process()
   }
 }
 
-Bool_t PdgCodeFilter::isBHadron(const unsigned int absPdgId) {
+Bool_t PdgCodeFilter::isBCSHadron(const unsigned int absPdgId) {
   if (absPdgId <= 100)
     return false;  // Fundamental particles and MC internals
   if (absPdgId >= 1000000000)
@@ -172,6 +172,16 @@ Bool_t PdgCodeFilter::isBHadron(const unsigned int absPdgId) {
     return true;  // B mesons
   if (nq1 == 5)
     return true;  // B baryons
+
+  if (nq1 == 0 and nq2 == 4)
+    return true;  // C mesons
+  if (nq1 == 4)
+    return true;  // C baryons
+
+  if (nq1 == 0 and nq2 == 3)
+    return true;  // S mesons
+  if (nq1 == 3)
+    return true;  // S baryons
 
   return false;
 }

--- a/modules/PdgCodeFilter.cc
+++ b/modules/PdgCodeFilter.cc
@@ -132,7 +132,7 @@ void PdgCodeFilter::Process()
       if (isBHadron(abs(pdgCode)) ){
         candidate->PT = candidate->PT * 1e-18;
         if (candidate->PT ==0) candidate->PT = 1e-18;
-        candidate->Momentum.SetPtEtaPhiM(candidate->PT, candidate->Momentum.Eta(), candidate->Phi, candidate->Momentum.M());
+        candidate->Momentum.SetPtEtaPhiM(candidate->PT, candidate->Momentum.Eta(), candidate->Momentum.Phi(), candidate->Momentum.M());
         fOutputArray->Add(candidate);
         continue;
       }

--- a/modules/PdgCodeFilter.cc
+++ b/modules/PdgCodeFilter.cc
@@ -128,7 +128,7 @@ void PdgCodeFilter::Process()
     pdgCode = candidate->PID;
 
     if (fRequireKeepGhostHadron) {
-      if (isBCSHadron(abs(pdgCode)) ){
+      if (isHadron(abs(pdgCode)) && candidate->Status != fStatus ){
         candidate->PT = candidate->PT * 1e-18;
         if (candidate->PT ==0) candidate->PT = 1e-18;
         candidate->Momentum.SetPtEtaPhiM(candidate->PT, candidate->Momentum.Eta(), candidate->Momentum.Phi(), candidate->Momentum.M());
@@ -153,7 +153,7 @@ void PdgCodeFilter::Process()
   }
 }
 
-Bool_t PdgCodeFilter::isBCSHadron(const unsigned int absPdgId) {
+Bool_t PdgCodeFilter::isHadron(const unsigned int absPdgId) {
   if (absPdgId <= 100)
     return false;  // Fundamental particles and MC internals
   if (absPdgId >= 1000000000)
@@ -182,6 +182,17 @@ Bool_t PdgCodeFilter::isBCSHadron(const unsigned int absPdgId) {
     return true;  // S mesons
   if (nq1 == 3)
     return true;  // S baryons
+
+  if (nq1 == 0 and nq2 == 2)
+    return true;  // U mesons
+  if (nq1 == 2)
+    return true;  // U baryons
+
+  if (nq1 == 0 and nq2 == 1)
+    return true;  // D mesons
+  if (nq1 == 1)
+    return true;  // D baryons
+
 
   return false;
 }

--- a/modules/PdgCodeFilter.h
+++ b/modules/PdgCodeFilter.h
@@ -54,7 +54,11 @@ private:
   Int_t fCharge; //!
   Bool_t fRequireNotPileup; //!
 
+  Bool_t fRequireKeepGhostBHadron; //!
+
   std::vector<Int_t> fPdgCodes;
+
+  Bool_t isBHadron(const unsigned int absPdgId); //!
 
   TIterator *fItInputArray; //!
 

--- a/modules/PdgCodeFilter.h
+++ b/modules/PdgCodeFilter.h
@@ -58,7 +58,7 @@ private:
 
   std::vector<Int_t> fPdgCodes;
 
-  Bool_t isBCSHadron(const unsigned int absPdgId); //!
+  Bool_t isHadron(const unsigned int absPdgId); //!
 
   TIterator *fItInputArray; //!
 

--- a/modules/PdgCodeFilter.h
+++ b/modules/PdgCodeFilter.h
@@ -54,11 +54,11 @@ private:
   Int_t fCharge; //!
   Bool_t fRequireNotPileup; //!
 
-  Bool_t fRequireKeepGhostBHadron; //!
+  Bool_t fRequireKeepGhostHadron; //!
 
   std::vector<Int_t> fPdgCodes;
 
-  Bool_t isBHadron(const unsigned int absPdgId); //!
+  Bool_t isBCSHadron(const unsigned int absPdgId); //!
 
   TIterator *fItInputArray; //!
 


### PR DESCRIPTION
This update is for adding a option  "RequireKeepGhostBHadron" in modules/PdgCodeFilter.cc .

If we add it, we can take the ghostBhadron particles in the jet constituents.

i have tested it, myself,  
The genjet is not change(affect) by the ghost-bhadron. 
because pt of the bhadron  is very small. 