### PR TITLE
Make sure to install all FCC cards

### DIFF
--- a/cards/CMakeLists.txt
+++ b/cards/CMakeLists.txt
@@ -1,8 +1,11 @@
 file(GLOB confDir *.tcl)
-file(GLOB confFccDir FCC/*.tcl)
-file(GLOB confCmsPhase2Dir CMS_PhaseII/*.tcl)
-
 # copy *.tcl files into cards
 install(FILES ${confDir} DESTINATION cards)
-install(FILES ${confFccDir} DESTINATION cards/FCC)
-install(FILES ${confCmsPhase2Dir} DESTINATION cards/CMS_PhaseII)
+
+# Install FCC cards into subfolder, including scenarios subdirectory
+install(DIRECTORY FCC DESTINATION cards
+  FILES_MATCHING PATTERN "*.tcl")
+
+# Install CMS_PhaseII cards into subfolder
+install(DIRECTORY CMS_PhaseII DESTINATION cards
+  FILES_MATCHING PATTERN "*.tcl")


### PR DESCRIPTION
In the current CMake configuration the cards in `FCC/scenarios` are not installed. These changes make sure to also install that subfolder. Switching to a similar approach for the CMS_PhaseII cards, to avoid the `file(GLOB)` construct there as well.