### PR TITLE
Fix memory leaks in VertexFit and VertexMore

### DIFF
--- a/external/TrackCovariance/VertexFit.cc
+++ b/external/TrackCovariance/VertexFit.cc
@@ -330,6 +330,8 @@ void  VertexFit::VertexFitter()
 		// Reset work arrays
 		//
 		ResetWrkArrays();
+
+
 		//
 		// Start loop on tracks
 		//
@@ -390,8 +392,10 @@ void  VertexFit::VertexFitter()
 			TVectorD b = (*fWi[i]) * (x - *fx0i[i] + *fdi[i]);
 			ffi[i] += Dot(a, b) / fa2i[i];
 			TVectorD newPar = *fPar[i] - ((*fCov[i]) * (*fAti[i])) * lambda;
+                        if ( fParNew[i] ) delete fParNew[i];
 			fParNew[i] = new TVectorD(newPar);
 			TMatrixDSym newCov = GetNewCov(i);
+                        if ( fCovNew[i] ) delete fCovNew[i];
 			fCovNew[i] = new TMatrixDSym(newCov);
 		}
 		// Add external constraint to Chi2

--- a/external/TrackCovariance/VertexMore.cc
+++ b/external/TrackCovariance/VertexMore.cc
@@ -614,8 +614,10 @@ void VertexMore::MassConstrFit()
 		TVectorD pm = p.GetSub(3*i+3,3*i+5);
 		TVector3 p3(pm(0), pm(1), pm(2));
 		Ptot += p3;
+                if ( fpi[i] ) delete fpi[i];
 		fpi[i] = new TVector3(p3);
 		TMatrixDSym Cpm = CovP.GetSub(3*i+3,3*i+5,3*i+3,3*i+5);
+                if ( fCpi[i] ) delete fCpi[i] ;
 		fCpi[i] = new TMatrixDSym(Cpm);
 	}
 	fP = Ptot;


### PR DESCRIPTION
(pointers created in a loop, hence the memory cleanup in the destructors was not complete)