### PR TITLE
fix: forward declaration of Points

### DIFF
--- a/external/fastjet/ClosestPair2D.cc
+++ b/external/fastjet/ClosestPair2D.cc
@@ -39,6 +39,16 @@ FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
 
 const unsigned int twopow31      = 2147483648U;
 
+ClosestPair2D::ClosestPair2D(const std::vector<Coord2D> & positions,
+  const Coord2D & left_corner, const Coord2D & right_corner) {
+  _initialize(positions, left_corner, right_corner, positions.size());
+};
+ClosestPair2D::ClosestPair2D(const std::vector<Coord2D> & positions,
+  const Coord2D & left_corner, const Coord2D & right_corner,
+  const unsigned int max_size) {
+  _initialize(positions, left_corner, right_corner, max_size);
+};
+
 using namespace std;
 
 //----------------------------------------------------------------------

--- a/external/fastjet/internal/ClosestPair2D.hh
+++ b/external/fastjet/internal/ClosestPair2D.hh
@@ -54,18 +54,14 @@ public:
   /// after insertion and deletion must never exceed positions.size();
   /// objects are given IDs that correspond to their index in the vector 
   /// of positions
-  ClosestPair2D(const std::vector<Coord2D> & positions, 
-		const Coord2D & left_corner, const Coord2D & right_corner) {
-    _initialize(positions, left_corner, right_corner, positions.size());
-  };
+  ClosestPair2D(const std::vector<Coord2D> & positions,
+		const Coord2D & left_corner, const Coord2D & right_corner);
 
   /// constructor which allows structure to grow beyond positions.size(), up
   /// to max_size
   ClosestPair2D(const std::vector<Coord2D> & positions, 
 		const Coord2D & left_corner, const Coord2D & right_corner,
-		const unsigned int max_size) {
-    _initialize(positions, left_corner, right_corner, max_size);
-  };
+		const unsigned int max_size);
 
   /// provides the IDs of the closest pair as well as the distance between
   /// them


### PR DESCRIPTION
as part of conda-forge/staged-recipes#27903 , it was observed some issues with the type of `ClosestPoint2D::Point` which gave errors like

```
In file included from /Users/runner/Miniforge3/conda-bld/delphes_1729113696054/work/external/fastjet/internal/ClosestPair2D.hh:34:
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/_build_env/bin/../include/c++/v1/vector:944:62: error: arithmetic on a pointer to an incomplete type 'fastjet::ClosestPair2D::Point'
  944 |         __alloc_traits::destroy(__alloc(), std::__to_address(--__soon_to_be_end));
      |                                                              ^ ~~~~~~~~~~~~~~~~
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/_build_env/bin/../include/c++/v1/vector:938:29: note: in instantiation of member function 'std::vector<fastjet::ClosestPair2D::Point>::__base_destruct_at_end' requested here
  938 |   void __clear() _NOEXCEPT {__base_destruct_at_end(this->__begin_);}
      |                             ^
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/_build_env/bin/../include/c++/v1/vector:489:20: note: in instantiation of member function 'std::vector<fastjet::ClosestPair2D::Point>::__clear' requested here
  489 |             __vec_.__clear();
      |                    ^
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/_build_env/bin/../include/c++/v1/vector:500:67: note: in instantiation of member function 'std::vector<fastjet::ClosestPair2D::Point>::__destroy_vector::operator()' requested here
  500 |   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI ~vector() { __destroy_vector(*this)(); }
      |                                                                   ^
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/work/external/fastjet/internal/ClosestPair2D.hh:57:3: note: in instantiation of member function 'std::vector<fastjet::ClosestPair2D::Point>::~vector' requested here
   57 |   ClosestPair2D(const std::vector<Coord2D> & positions,
      |   ^
/Users/runner/Miniforge3/conda-bld/delphes_1729113696054/work/external/fastjet/internal/ClosestPair2D.hh:110:9: note: forward declaration of 'fastjet::ClosestPair2D::Point'
  110 |   class Point; // will be defined below
      |         ^
```

however, if you explore in the code, you'll notice that indeed, one is relying on `positions.size()` in the definition in the header file before `Points` is actually defined (simply forward-declared) so I think this error from the compiler is actually valid. It remains to be understood why this was not reproducible outside of `conda` but that is maybe out of my expertise... In any case, moving the constructor of `ClosestPoint2D` to the source file instead seems to fix it.
