### PR TITLE
ProtoJet.hpp: fix no-member _Et

### DIFF
--- a/external/fastjet/plugins/D0RunIICone/ProtoJet.hpp
+++ b/external/fastjet/plugins/D0RunIICone/ProtoJet.hpp
@@ -195,7 +195,7 @@ void ProtoJet<Item>::NowStable() {
 
 template<class Item>
 void ProtoJet<Item>::print(std::ostream& os) const {
-  os<<"y phi Et = ("<<_y<<", "<<_phi<<", "<<this->_Et<<")"<<std::endl;
+  os<<"y phi pT = ("<<_y<<", "<<_phi<<", "<<this->_pT<<")"<<std::endl;
   os<< " members= " << std::endl;
   typename std::list<const Item*>::const_iterator i;
   for(i = _LItems.begin(); i != _LItems.end(); ++i)


### PR DESCRIPTION
Compiling with clang19 makes this error show up for some reason...