### PR TITLE
Link to the ROOT libraries that are being used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ add_library(Delphes SHARED
   $<TARGET_OBJECTS:TrackCovariance>
 )
 
-target_link_libraries(Delphes ${ROOT_LIBRARIES})
+target_link_libraries(Delphes PUBLIC ROOT::Core ROOT::Hist ROOT::Tree ROOT::MathCore ROOT::Physics ROOT::EG)
 
 if(PYTHIA8_FOUND)
   target_link_libraries(Delphes ${PYTHIA8_LIBRARIES} ${CMAKE_DL_LIBS})
@@ -81,6 +81,6 @@ add_library(DelphesDisplay SHARED
   $<TARGET_OBJECTS:display>
 )
 
-target_link_libraries(DelphesDisplay Delphes)
+target_link_libraries(DelphesDisplay Delphes ROOT::Geom ROOT::Graf3d ROOT::RGL ROOT::Eve ROOT::GuiHtml)
 
 install(TARGETS Delphes DelphesDisplay DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,13 @@ add_library(Delphes SHARED
 target_link_libraries(Delphes PUBLIC ROOT::Core ROOT::Hist ROOT::Tree ROOT::MathCore ROOT::Physics ROOT::EG)
 
 if(PYTHIA8_FOUND)
-  target_link_libraries(Delphes ${PYTHIA8_LIBRARIES} ${CMAKE_DL_LIBS})
+  target_link_libraries(Delphes PUBLIC ${PYTHIA8_LIBRARIES} ${CMAKE_DL_LIBS})
 endif()
 
 add_library(DelphesDisplay SHARED
   $<TARGET_OBJECTS:display>
 )
 
-target_link_libraries(DelphesDisplay Delphes ROOT::Geom ROOT::Graf3d ROOT::RGL ROOT::Eve ROOT::GuiHtml)
+target_link_libraries(DelphesDisplay PUBLIC Delphes ROOT::Geom ROOT::Graf3d ROOT::RGL ROOT::Eve ROOT::GuiHtml)
 
 install(TARGETS Delphes DelphesDisplay DESTINATION lib)


### PR DESCRIPTION
The current way makes builds on MacOS fail in the LCG stacks because not every used library is being linked. Linking using the targes (the more modern way of doing it) makes it work.