### PR TITLE
MNT: Use range of allowed CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(Delphes)
 


### PR DESCRIPTION
* Modern use of cmake_minimum_required allows for a range of supported CMake version policies to be used, which allows for newer versions of CMake to be supported without errors as well as for more efficient builds with newer releases.
   - The optional <policy_max> argument was added in CMake v3.12 and is ignored in older releases, which allows it to be used even if an older CMake release / policy is used.
   - In CMake v4.0 compatibility with versions of CMake older than 3.5 is removed.