### PR TITLE
Make Trklen function const

### DIFF
--- a/external/TrackCovariance/TrkUtil.cc
+++ b/external/TrackCovariance/TrkUtil.cc
@@ -942,7 +942,7 @@ void TrkUtil::SetDchBoundaries(Double_t Rmin, Double_t Rmax, Double_t Zmin, Doub
 }
 //
 // Get Trakck length inside DCH volume
-Double_t TrkUtil::TrkLen(TVectorD Par)
+Double_t TrkUtil::TrkLen(TVectorD Par) const
 {
 	Double_t tLength = 0.0;
 	// Check if geometry is initialized

--- a/external/TrackCovariance/TrkUtil.h
+++ b/external/TrackCovariance/TrkUtil.h
@@ -125,7 +125,7 @@ public:
 	Double_t Nclusters(Double_t bgam);	// mean clusters/meter vs beta*gamma
 	static Double_t Nclusters(Double_t bgam, Int_t Opt);	// mean clusters/meter vs beta*gamma
 	Double_t funcNcl(Double_t *xp, Double_t *par);
-	Double_t TrkLen(TVectorD Par);					// Track length inside chamber
+	Double_t TrkLen(TVectorD Par) const;					// Track length inside chamber
 };
 
 #endif


### PR DESCRIPTION
Hi,
I'm working on implementing a Gaudi functional that uses the delphes parametrisation to assign a dN/dx value to tracks.
For this I'm using an instance of the delphes `TrkUtil` class. 
However, I can't call the `TrkLen` function in my algorithm, since my Gaudi functional needs to be constant:
`edm4hep::RecDqdxCollection TrackdNdxDelphesBased::operator()(...) const`
Compilation error: ` error: passing 'const TrkUtil' as 'this' argument discards qualifiers [-fpermissive]`

An easy fix would be to mark the function `TrkLen` as `const`, which as far as I can see, should be no problem (there are no modifications of member variables)
Hence, this PR.

Thanks!
                                                            