### PR TITLE
Make TrkUtil::TrkLen const

### DIFF
--- a/external/TrackCovariance/TrkUtil.cc
+++ b/external/TrackCovariance/TrkUtil.cc
@@ -979,7 +979,7 @@ void TrkUtil::SetDchBoundaries(Double_t Rmin, Double_t Rmax, Double_t Zmin, Doub
 }
 //
 // Get Trakck length inside DCH volume
-Double_t TrkUtil::TrkLen(TVectorD Par)
+Double_t TrkUtil::TrkLen(TVectorD Par) const
 {
 	Double_t tLength = 0.0;
 	// Check if geometry is initialized

--- a/external/TrackCovariance/TrkUtil.h
+++ b/external/TrackCovariance/TrkUtil.h
@@ -129,7 +129,7 @@ public:
 	Double_t Nclusters(Double_t bgam);	// mean clusters/meter vs beta*gamma
 	static Double_t Nclusters(Double_t bgam, Int_t Opt);	// mean clusters/meter vs beta*gamma
 	Double_t funcNcl(Double_t *xp, Double_t *par);
-	Double_t TrkLen(TVectorD Par);					// Track length inside chamber
+	Double_t TrkLen(TVectorD Par) const;	 				// Track length inside chamber
 };
 
 #endif


### PR DESCRIPTION
Originally included in cf76a9e3 (https://github.com/delphes/delphes/pull/160) and removed (seemingly without reason) in
9f420646 (see https://github.com/delphes/delphes/pull/167#discussion_r2343061767)