### PR TITLE
Default value for mLast set to -1 not 0 in methods for covariance matrix estimation with Kalman filter

### DIFF
--- a/external/TrackCovariance/SolTrack.cc
+++ b/external/TrackCovariance/SolTrack.cc
@@ -1141,7 +1141,7 @@ void SolTrack::KalmanCov(Bool_t Res, Bool_t MS, Double_t mass)
 	//
 	Double_t *thms = new Double_t[Nhit];		// Scattering angles/plane
 	//
-	Int_t mLast = 0;				// Last measurement layer
+	Int_t mLast = -1;				// Last measurement layer
 	for (Int_t ii = 0; ii < Nhit; ii++)		// Hit layer loop
 	{
 		
@@ -1425,7 +1425,7 @@ void SolTrack::KalmanCovT(Bool_t Res, Bool_t MS, Double_t mass)
 	//
 	Double_t *thms = new Double_t[Nhit];		// Scattering angles/plane
 	//
-	Int_t mLast = 0;				// Last measurement layer
+	Int_t mLast = -1;				// Last measurement layer
 	for (Int_t ii = 0; ii < Nhit; ii++)		// Hit layer loop
 	{
 


### PR DESCRIPTION
Setting the default value to -1 prevents executing the loop over all layers starting with last measurement layer when there are no hits.