### PR TITLE
updating DelphesPythia8 and TreeWriter

### DIFF
--- a/modules/TreeWriter.cc
+++ b/modules/TreeWriter.cc
@@ -44,9 +44,9 @@
 #include "TRandom3.h"
 #include "TString.h"
 
+#include <set>
 #include <algorithm>
 #include <iostream>
-#include <set>
 #include <sstream>
 #include <stdexcept>
 
@@ -252,6 +252,7 @@ void TreeWriter::ProcessParticles(ExRootTreeBranch *branch, TObjArray *array)
     entry->Y = position.Y();
     entry->Z = position.Z();
     entry->T = position.T() * 1.0E-3 / c_light;
+
   }
 }
 
@@ -382,16 +383,16 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->ErrorCtgTheta = candidate->ErrorCtgTheta;
 
     // add some offdiagonal covariance matrix elements
-    entry->ErrorD0Phi = candidate->TrackCovariance(0, 1) * 1.e3;
-    entry->ErrorD0C = candidate->TrackCovariance(0, 2);
-    entry->ErrorD0DZ = candidate->TrackCovariance(0, 3) * 1.e6;
-    entry->ErrorD0CtgTheta = candidate->TrackCovariance(0, 4) * 1.e3;
-    entry->ErrorPhiC = candidate->TrackCovariance(1, 2) * 1.e-3;
-    entry->ErrorPhiDZ = candidate->TrackCovariance(1, 3) * 1.e3;
-    entry->ErrorPhiCtgTheta = candidate->TrackCovariance(1, 4);
-    entry->ErrorCDZ = candidate->TrackCovariance(2, 3);
-    entry->ErrorCCtgTheta = candidate->TrackCovariance(2, 4) * 1.e-3;
-    entry->ErrorDZCtgTheta = candidate->TrackCovariance(3, 4) * 1.e3;
+    entry->ErrorD0Phi          = candidate->TrackCovariance(0,1)*1.e3;
+    entry->ErrorD0C            = candidate->TrackCovariance(0,2);
+    entry->ErrorD0DZ           = candidate->TrackCovariance(0,3)*1.e6;
+    entry->ErrorD0CtgTheta     = candidate->TrackCovariance(0,4)*1.e3;
+    entry->ErrorPhiC           = candidate->TrackCovariance(1,2)*1.e-3;
+    entry->ErrorPhiDZ          = candidate->TrackCovariance(1,3)*1.e3;
+    entry->ErrorPhiCtgTheta    = candidate->TrackCovariance(1,4);
+    entry->ErrorCDZ            = candidate->TrackCovariance(2,3);
+    entry->ErrorCCtgTheta      = candidate->TrackCovariance(2,4)*1.e-3;
+    entry->ErrorDZCtgTheta     = candidate->TrackCovariance(3,4)*1.e3;
 
     entry->Xd = candidate->Xd;
     entry->Yd = candidate->Yd;
@@ -429,7 +430,7 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->Y = initialPosition.Y();
     entry->Z = initialPosition.Z();
     entry->T = initialPosition.T() * 1.0E-3 / c_light;
-    entry->ErrorT = candidate->ErrorT * 1.0E-3 / c_light;
+    entry->ErrorT =candidate-> ErrorT * 1.0E-3 / c_light;
 
     entry->Particle = particle;
 
@@ -439,6 +440,7 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->IsRecoPU = candidate->IsRecoPU;
     entry->HardEnergyFraction = candidate->IsPU ? 0.0 : 1.0;
   }
+
 }
 
 //------------------------------------------------------------------------------
@@ -529,7 +531,7 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
 
     entry->Charge = candidate->Charge;
 
-    if(TMath::Abs(entry->Charge) > 0.)
+    if (TMath::Abs(entry->Charge) > 0.)
     {
       entry->HardEnergyFraction = entry->IsPU ? 0.0 : 1.0;
     }
@@ -566,16 +568,16 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
     entry->ErrorCtgTheta = candidate->ErrorCtgTheta;
 
     // add some offdiagonal covariance matrix elements
-    entry->ErrorD0Phi = candidate->TrackCovariance(0, 1);
-    entry->ErrorD0C = candidate->TrackCovariance(0, 2);
-    entry->ErrorD0DZ = candidate->TrackCovariance(0, 3);
-    entry->ErrorD0CtgTheta = candidate->TrackCovariance(0, 4);
-    entry->ErrorPhiC = candidate->TrackCovariance(1, 2);
-    entry->ErrorPhiDZ = candidate->TrackCovariance(1, 3);
-    entry->ErrorPhiCtgTheta = candidate->TrackCovariance(1, 4);
-    entry->ErrorCDZ = candidate->TrackCovariance(2, 3);
-    entry->ErrorCCtgTheta = candidate->TrackCovariance(2, 4);
-    entry->ErrorDZCtgTheta = candidate->TrackCovariance(3, 4);
+    entry->ErrorD0Phi          = candidate->TrackCovariance(0,1);
+    entry->ErrorD0C            = candidate->TrackCovariance(0,2);
+    entry->ErrorD0DZ           = candidate->TrackCovariance(0,3);
+    entry->ErrorD0CtgTheta     = candidate->TrackCovariance(0,4);
+    entry->ErrorPhiC           = candidate->TrackCovariance(1,2);
+    entry->ErrorPhiDZ          = candidate->TrackCovariance(1,3);
+    entry->ErrorPhiCtgTheta    = candidate->TrackCovariance(1,4);
+    entry->ErrorCDZ            = candidate->TrackCovariance(2,3);
+    entry->ErrorCCtgTheta      = candidate->TrackCovariance(2,4);
+    entry->ErrorDZCtgTheta     = candidate->TrackCovariance(3,4);
 
     entry->Xd = candidate->Xd;
     entry->Yd = candidate->Yd;
@@ -613,7 +615,7 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
     entry->Y = initialPosition.Y();
     entry->Z = initialPosition.Z();
     entry->T = initialPosition.T() * 1.0E-3 / c_light;
-    entry->ErrorT = candidate->ErrorT * 1.0E-3 / c_light;
+    entry->ErrorT = candidate-> ErrorT * 1.0E-3 / c_light;
 
     entry->VertexIndex = candidate->ClusterIndex;
 
@@ -959,22 +961,23 @@ void TreeWriter::ProcessCscCluster(ExRootTreeBranch *branch, TObjArray *array)
     entry->Phi = momentum.Phi();
 
     entry->PT = momentum.Pt(); // pt of LLP
-    entry->Px = momentum.Px(); // px of LLP
-    entry->Py = momentum.Py(); // py of LLP
-    entry->Pz = momentum.Pz(); // pz of LLP
+    entry->Px = momentum.Px();// px of LLP
+    entry->Py = momentum.Py();// py of LLP
+    entry->Pz = momentum.Pz();// pz of LLP
     entry->E = momentum.E(); // E of LLP
     entry->pid = candidate->PID; // LLP pid
     entry->Eem = candidate->Eem; // LLP Eem
     entry->Ehad = candidate->Ehad; // LLP Ehad
-    Double_t beta = momentum.P() / momentum.E();
-    Double_t gamma = 1.0 / sqrt(1 - beta * beta);
-    Double_t decayDistance = sqrt(pow(position.X(), 2) + pow(position.Y(), 2) + pow(position.Z(), 2)); // mm
+    Double_t beta = momentum.P()/momentum.E();
+    Double_t gamma = 1.0/sqrt(1-beta*beta);
+    Double_t decayDistance = sqrt(pow(position.X(),2)+pow(position.Y(),2)+pow(position.Z(),2)); // mm
     entry->beta = beta; // LLP pid
-    entry->ctau = decayDistance / (beta * gamma); // LLP travel time in its rest frame
-    entry->T = decayDistance * (1. / beta - 1) * 1.0E-3 / c_light * 1e9; // ns
+    entry->ctau = decayDistance/(beta * gamma); // LLP travel time in its rest frame
+    entry->T = decayDistance*(1./beta-1)* 1.0E-3/c_light*1e9; // ns
     entry->X = position.X(); // LLP decay x
     entry->Y = position.Y(); //  LLP decay y
     entry->Z = position.Z(); //  LLP decay z
+    entry->R = sqrt(pow(position.X(),2)+pow(position.Y(),2)); // LLP distance in transverse plane
   }
 }
 

--- a/modules/TreeWriter.cc
+++ b/modules/TreeWriter.cc
@@ -44,9 +44,9 @@
 #include "TRandom3.h"
 #include "TString.h"
 
-#include <set>
 #include <algorithm>
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 
@@ -252,7 +252,6 @@ void TreeWriter::ProcessParticles(ExRootTreeBranch *branch, TObjArray *array)
     entry->Y = position.Y();
     entry->Z = position.Z();
     entry->T = position.T() * 1.0E-3 / c_light;
-
   }
 }
 
@@ -383,16 +382,16 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->ErrorCtgTheta = candidate->ErrorCtgTheta;
 
     // add some offdiagonal covariance matrix elements
-    entry->ErrorD0Phi          = candidate->TrackCovariance(0,1)*1.e3;
-    entry->ErrorD0C            = candidate->TrackCovariance(0,2);
-    entry->ErrorD0DZ           = candidate->TrackCovariance(0,3)*1.e6;
-    entry->ErrorD0CtgTheta     = candidate->TrackCovariance(0,4)*1.e3;
-    entry->ErrorPhiC           = candidate->TrackCovariance(1,2)*1.e-3;
-    entry->ErrorPhiDZ          = candidate->TrackCovariance(1,3)*1.e3;
-    entry->ErrorPhiCtgTheta    = candidate->TrackCovariance(1,4);
-    entry->ErrorCDZ            = candidate->TrackCovariance(2,3);
-    entry->ErrorCCtgTheta      = candidate->TrackCovariance(2,4)*1.e-3;
-    entry->ErrorDZCtgTheta     = candidate->TrackCovariance(3,4)*1.e3;
+    entry->ErrorD0Phi = candidate->TrackCovariance(0, 1) * 1.e3;
+    entry->ErrorD0C = candidate->TrackCovariance(0, 2);
+    entry->ErrorD0DZ = candidate->TrackCovariance(0, 3) * 1.e6;
+    entry->ErrorD0CtgTheta = candidate->TrackCovariance(0, 4) * 1.e3;
+    entry->ErrorPhiC = candidate->TrackCovariance(1, 2) * 1.e-3;
+    entry->ErrorPhiDZ = candidate->TrackCovariance(1, 3) * 1.e3;
+    entry->ErrorPhiCtgTheta = candidate->TrackCovariance(1, 4);
+    entry->ErrorCDZ = candidate->TrackCovariance(2, 3);
+    entry->ErrorCCtgTheta = candidate->TrackCovariance(2, 4) * 1.e-3;
+    entry->ErrorDZCtgTheta = candidate->TrackCovariance(3, 4) * 1.e3;
 
     entry->Xd = candidate->Xd;
     entry->Yd = candidate->Yd;
@@ -430,7 +429,7 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->Y = initialPosition.Y();
     entry->Z = initialPosition.Z();
     entry->T = initialPosition.T() * 1.0E-3 / c_light;
-    entry->ErrorT =candidate-> ErrorT * 1.0E-3 / c_light;
+    entry->ErrorT = candidate->ErrorT * 1.0E-3 / c_light;
 
     entry->Particle = particle;
 
@@ -440,7 +439,6 @@ void TreeWriter::ProcessTracks(ExRootTreeBranch *branch, TObjArray *array)
     entry->IsRecoPU = candidate->IsRecoPU;
     entry->HardEnergyFraction = candidate->IsPU ? 0.0 : 1.0;
   }
-
 }
 
 //------------------------------------------------------------------------------
@@ -531,7 +529,7 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
 
     entry->Charge = candidate->Charge;
 
-    if (TMath::Abs(entry->Charge) > 0.)
+    if(TMath::Abs(entry->Charge) > 0.)
     {
       entry->HardEnergyFraction = entry->IsPU ? 0.0 : 1.0;
     }
@@ -568,16 +566,16 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
     entry->ErrorCtgTheta = candidate->ErrorCtgTheta;
 
     // add some offdiagonal covariance matrix elements
-    entry->ErrorD0Phi          = candidate->TrackCovariance(0,1);
-    entry->ErrorD0C            = candidate->TrackCovariance(0,2);
-    entry->ErrorD0DZ           = candidate->TrackCovariance(0,3);
-    entry->ErrorD0CtgTheta     = candidate->TrackCovariance(0,4);
-    entry->ErrorPhiC           = candidate->TrackCovariance(1,2);
-    entry->ErrorPhiDZ          = candidate->TrackCovariance(1,3);
-    entry->ErrorPhiCtgTheta    = candidate->TrackCovariance(1,4);
-    entry->ErrorCDZ            = candidate->TrackCovariance(2,3);
-    entry->ErrorCCtgTheta      = candidate->TrackCovariance(2,4);
-    entry->ErrorDZCtgTheta     = candidate->TrackCovariance(3,4);
+    entry->ErrorD0Phi = candidate->TrackCovariance(0, 1);
+    entry->ErrorD0C = candidate->TrackCovariance(0, 2);
+    entry->ErrorD0DZ = candidate->TrackCovariance(0, 3);
+    entry->ErrorD0CtgTheta = candidate->TrackCovariance(0, 4);
+    entry->ErrorPhiC = candidate->TrackCovariance(1, 2);
+    entry->ErrorPhiDZ = candidate->TrackCovariance(1, 3);
+    entry->ErrorPhiCtgTheta = candidate->TrackCovariance(1, 4);
+    entry->ErrorCDZ = candidate->TrackCovariance(2, 3);
+    entry->ErrorCCtgTheta = candidate->TrackCovariance(2, 4);
+    entry->ErrorDZCtgTheta = candidate->TrackCovariance(3, 4);
 
     entry->Xd = candidate->Xd;
     entry->Yd = candidate->Yd;
@@ -615,7 +613,7 @@ void TreeWriter::ProcessParticleFlowCandidates(ExRootTreeBranch *branch, TObjArr
     entry->Y = initialPosition.Y();
     entry->Z = initialPosition.Z();
     entry->T = initialPosition.T() * 1.0E-3 / c_light;
-    entry->ErrorT = candidate-> ErrorT * 1.0E-3 / c_light;
+    entry->ErrorT = candidate->ErrorT * 1.0E-3 / c_light;
 
     entry->VertexIndex = candidate->ClusterIndex;
 
@@ -961,19 +959,19 @@ void TreeWriter::ProcessCscCluster(ExRootTreeBranch *branch, TObjArray *array)
     entry->Phi = momentum.Phi();
 
     entry->PT = momentum.Pt(); // pt of LLP
-    entry->Px = momentum.Px();// px of LLP
-    entry->Py = momentum.Py();// py of LLP
-    entry->Pz = momentum.Pz();// pz of LLP
+    entry->Px = momentum.Px(); // px of LLP
+    entry->Py = momentum.Py(); // py of LLP
+    entry->Pz = momentum.Pz(); // pz of LLP
     entry->E = momentum.E(); // E of LLP
     entry->pid = candidate->PID; // LLP pid
     entry->Eem = candidate->Eem; // LLP Eem
     entry->Ehad = candidate->Ehad; // LLP Ehad
-    Double_t beta = momentum.P()/momentum.E();
-    Double_t gamma = 1.0/sqrt(1-beta*beta);
-    Double_t decayDistance = sqrt(pow(position.X(),2)+pow(position.Y(),2)+pow(position.Z(),2)); // mm
+    Double_t beta = momentum.P() / momentum.E();
+    Double_t gamma = 1.0 / sqrt(1 - beta * beta);
+    Double_t decayDistance = sqrt(pow(position.X(), 2) + pow(position.Y(), 2) + pow(position.Z(), 2)); // mm
     entry->beta = beta; // LLP pid
-    entry->ctau = decayDistance/(beta * gamma); // LLP travel time in its rest frame
-    entry->T = decayDistance*(1./beta-1)* 1.0E-3/c_light*1e9; // ns
+    entry->ctau = decayDistance / (beta * gamma); // LLP travel time in its rest frame
+    entry->T = decayDistance * (1. / beta - 1) * 1.0E-3 / c_light * 1e9; // ns
     entry->X = position.X(); // LLP decay x
     entry->Y = position.Y(); //  LLP decay y
     entry->Z = position.Z(); //  LLP decay z

--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -104,11 +104,15 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     pz = particle.pz();
     e = particle.e();
     mass = particle.m();
-    x = particle.xProd();
-    y = particle.yProd();
-    z = particle.zProd();
-    t = particle.tProd();
-
+    x_initial = particle.xProd();
+    y_initial = particle.yProd();
+    z_initial = particle.zProd();
+    t_initial = particle.tProd();                                                                                                                                                                         
+    x_decay = particle.xDec();
+    y_decay = particle.yDec();
+    z_decay = particle.zDec();
+    t_decay = particle.tDec();
+    
     candidate = factory->NewCandidate();
 
     candidate->PID = pid;

--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -64,7 +64,8 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
 
   Int_t pid, status;
   Double_t px, py, pz, e, mass;
-  Double_t x, y, z, t;
+  Double_t x_initial, y_initial, z_initial, t_initial;
+  Double_t x_decay, y_decay, z_decay, t_decay;
 
   // event information
   element = static_cast<HepMCEvent *>(branch->NewEntry());
@@ -103,11 +104,17 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     pz = particle.pz();
     e = particle.e();
     mass = particle.m();
-    x = particle.xProd();
-    y = particle.yProd();
-    z = particle.zProd();
-    t = particle.tProd();
-
+    //production information
+    x_initial = particle.xProd();
+    y_initial = particle.yProd();
+    z_initial = particle.zProd();
+    t_initial = particle.tProd();
+    //decay information
+    x_decay = particle.xDec();
+    y_decay = particle.yDec();
+    z_decay = particle.zDec();
+    t_decay = particle.tDec();
+    
     candidate = factory->NewCandidate();
 
     candidate->PID = pid;
@@ -127,7 +134,9 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
 
     candidate->Momentum.SetPxPyPzE(px, py, pz, e);
 
-    candidate->Position.SetXYZT(x, y, z, t);
+    candidate->Position.SetXYZT(x_initial, y_initial, z_initial, t_initial);
+    candidate->InitialPosition.SetXYZT(x_initial, y_initial, z_initial, t_initial);
+    candidate->DecayPosition.SetXYZT(x_decay, y_decay, z_decay, t_decay);
 
     allParticleOutputArray->Add(candidate);
 
@@ -143,6 +152,7 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     }
   }
 }
+
 
 //---------------------------------------------------------------------------
 
@@ -328,7 +338,7 @@ int main(int argc, char *argv[])
     spareMode1 = pythia->mode("Main:spareMode1");
     spareParm1 = pythia->parm("Main:spareParm1");
     spareParm2 = pythia->parm("Main:spareParm2");
-
+        
     // Check if particle gun
     if(!spareFlag1)
     {
@@ -361,7 +371,8 @@ int main(int argc, char *argv[])
     readStopWatch.Start();
     for(eventCounter = 0; eventCounter < numberOfEvents && !interrupted; ++eventCounter)
     {
-      while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady());
+      while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady())
+        ;
 
       if(spareFlag1)
       {
@@ -420,7 +431,7 @@ int main(int argc, char *argv[])
         weight->Weight = pythia->info.weightValueVector()[iWeight];
       }
 #endif
-
+      
       treeWriter->Fill();
 
       treeWriter->Clear();

--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -66,7 +66,7 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
   Double_t px, py, pz, e, mass;
   Double_t x_initial, y_initial, z_initial, t_initial;
   Double_t x_decay, y_decay, z_decay, t_decay;
-
+  
   // event information
   element = static_cast<HepMCEvent *>(branch->NewEntry());
 
@@ -104,17 +104,11 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     pz = particle.pz();
     e = particle.e();
     mass = particle.m();
-    //production information
-    x_initial = particle.xProd();
-    y_initial = particle.yProd();
-    z_initial = particle.zProd();
-    t_initial = particle.tProd();
-    //decay information
-    x_decay = particle.xDec();
-    y_decay = particle.yDec();
-    z_decay = particle.zDec();
-    t_decay = particle.tDec();
-    
+    x = particle.xProd();
+    y = particle.yProd();
+    z = particle.zProd();
+    t = particle.tProd();
+
     candidate = factory->NewCandidate();
 
     candidate->PID = pid;
@@ -137,7 +131,7 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     candidate->Position.SetXYZT(x_initial, y_initial, z_initial, t_initial);
     candidate->InitialPosition.SetXYZT(x_initial, y_initial, z_initial, t_initial);
     candidate->DecayPosition.SetXYZT(x_decay, y_decay, z_decay, t_decay);
-
+    
     allParticleOutputArray->Add(candidate);
 
     if(!pdgParticle) continue;
@@ -152,7 +146,6 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     }
   }
 }
-
 
 //---------------------------------------------------------------------------
 
@@ -338,7 +331,7 @@ int main(int argc, char *argv[])
     spareMode1 = pythia->mode("Main:spareMode1");
     spareParm1 = pythia->parm("Main:spareParm1");
     spareParm2 = pythia->parm("Main:spareParm2");
-        
+
     // Check if particle gun
     if(!spareFlag1)
     {
@@ -371,8 +364,7 @@ int main(int argc, char *argv[])
     readStopWatch.Start();
     for(eventCounter = 0; eventCounter < numberOfEvents && !interrupted; ++eventCounter)
     {
-      while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady())
-        ;
+      while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady());
 
       if(spareFlag1)
       {
@@ -431,7 +423,7 @@ int main(int argc, char *argv[])
         weight->Weight = pythia->info.weightValueVector()[iWeight];
       }
 #endif
-      
+
       treeWriter->Fill();
 
       treeWriter->Clear();

--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -64,7 +64,7 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
 
   Int_t pid, status;
   Double_t px, py, pz, e, mass;
-  Double_t x_initial, y_initial, z_initial, t_initial;
+  Double_t x, y, z, t;
   Double_t x_decay, y_decay, z_decay, t_decay;
   
   // event information
@@ -104,10 +104,11 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
     pz = particle.pz();
     e = particle.e();
     mass = particle.m();
-    x_initial = particle.xProd();
-    y_initial = particle.yProd();
-    z_initial = particle.zProd();
-    t_initial = particle.tProd();                                                                                                                                                                         
+    x = particle.xProd();
+    y = particle.yProd();
+    z = particle.zProd();
+    t = particle.tProd();
+    
     x_decay = particle.xDec();
     y_decay = particle.yDec();
     z_decay = particle.zDec();
@@ -132,8 +133,7 @@ void ConvertInput(Long64_t eventCounter, Pythia8::Pythia *pythia,
 
     candidate->Momentum.SetPxPyPzE(px, py, pz, e);
 
-    candidate->Position.SetXYZT(x_initial, y_initial, z_initial, t_initial);
-    candidate->InitialPosition.SetXYZT(x_initial, y_initial, z_initial, t_initial);
+    candidate->Position.SetXYZT(x, y, z, t);
     candidate->DecayPosition.SetXYZT(x_decay, y_decay, z_decay, t_decay);
     
     allParticleOutputArray->Add(candidate);


### PR DESCRIPTION
I have noticed that when running ./DelphesPythia8 with the detector card delphes_card_CMS_CSCCluster.tcl and with Hidden Valley physics processes, the CSC-related branches appeared to be empty (only one non-empty was the gen LLP branch), even if this was not expected given the LLP particle lifetime. This was traced back to the fact that DecayPosition for all candidates is always set to 0, also for the LLP, when running DelphesPythia8.cpp. When LLPFilter is run with the option RequireDecayRegion=True, due to the DecayPosition variable set by default to zero, the LLP never passes such filter. I have added in DelphesPythia8.cpp the relevant information to have the correct DecayPosition not always set to zero, avoiding the aforementioned problem with the LLP filter (and CsCcluster).
After such modification, still the variable R (transverse displacement) was zero (default value). I have added to TreeWriter.cc a line to handle this in TreeWriter::ProcessCscCluster.