### PR TITLE
Fix event desynchronization after failed Pythia8 events

### DIFF
--- a/readers/DelphesPythia8.cpp
+++ b/readers/DelphesPythia8.cpp
@@ -368,7 +368,6 @@ int main(int argc, char *argv[])
     readStopWatch.Start();
     for(eventCounter = 0; eventCounter < numberOfEvents && !interrupted; ++eventCounter)
     {
-      while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady());
 
       if(spareFlag1)
       {
@@ -402,6 +401,16 @@ int main(int argc, char *argv[])
         reader->Clear();
         continue;
       }
+
+      // Advance the LHE reader for events that were tried but failed by Pythia8.
+      // Without this synchronization, the LHEF information and reconstructed
+      // Delphes branches correspond to different events after a failed generation.
+      int nTriedPythia = pythia->info.nTried();
+      while(nTriedPythia > eventCounter){
+        while(reader && reader->ReadBlock(factory, allParticleOutputArrayLHEF, stableParticleOutputArrayLHEF, partonOutputArrayLHEF) && !reader->EventReady());
+        eventCounter++;
+      }
+      eventCounter--;
 
       readStopWatch.Stop();
 


### PR DESCRIPTION
In DelphesPythia8.cpp, the LHE reader block and Pythia8 event stream could become desynchronized when Pythia8 failed to generate an event.

After a failed event, subsequent entries in the LHEF branch and reconstructed branches corresponded to different events, leading to incorrect event information and possible downstream analysis errors.

This patch ensures synchronization between the LHE reader and Pythia8 output stream after failed events.

To build Delphes with Pythia8 type 
   ./configure
   make -j<N> HAS_PYTHIA8=true PYTHIA8=<Pythia8 path>