### PR TITLE
Deprecate ReadBlock instead of removing it

### DIFF
--- a/classes/DelphesHepMC2Reader.h
+++ b/classes/DelphesHepMC2Reader.h
@@ -54,6 +54,15 @@ public:
     TObjArray *stableParticleOutputArray,
     TObjArray *partonOutputArray);
 
+  [[deprecated("ReadBlock has been renamed to ReadEvent")]]
+  bool ReadBlock(DelphesFactory *factory,
+    TObjArray *allParticleOutputArray,
+    TObjArray *stableParticleOutputArray,
+    TObjArray *partonOutputArray)
+  {
+    return ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray);
+  }
+
   void AnalyzeEvent(ExRootTreeBranch *branch, long long eventNumber,
     TStopwatch *readStopWatch, TStopwatch *procStopWatch);
 

--- a/classes/DelphesHepMC3Reader.h
+++ b/classes/DelphesHepMC3Reader.h
@@ -56,6 +56,15 @@ public:
     TObjArray *stableParticleOutputArray,
     TObjArray *partonOutputArray);
 
+  [[deprecated("ReadBlock has been renamed to ReadEvent")]]
+  bool ReadBlock(DelphesFactory *factory,
+    TObjArray *allParticleOutputArray,
+    TObjArray *stableParticleOutputArray,
+    TObjArray *partonOutputArray)
+  {
+    return ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray);
+  }
+
   void AnalyzeEvent(ExRootTreeBranch *branch, long long eventNumber,
     TStopwatch *readStopWatch, TStopwatch *procStopWatch);
 

--- a/classes/DelphesLHEFReader.h
+++ b/classes/DelphesLHEFReader.h
@@ -54,6 +54,15 @@ public:
     TObjArray *stableParticleOutputArray,
     TObjArray *partonOutputArray);
 
+  [[deprecated("ReadBlock has been renamed to ReadEvent")]]
+  bool ReadBlock(DelphesFactory *factory,
+    TObjArray *allParticleOutputArray,
+    TObjArray *stableParticleOutputArray,
+    TObjArray *partonOutputArray)
+  {
+    return ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray);
+  }
+
   void AnalyzeEvent(ExRootTreeBranch *branch, long long eventNumber,
     TStopwatch *readStopWatch, TStopwatch *procStopWatch);
 

--- a/classes/DelphesSTDHEPReader.h
+++ b/classes/DelphesSTDHEPReader.h
@@ -67,6 +67,15 @@ public:
     TObjArray *stableParticleOutputArray,
     TObjArray *partonOutputArray);
 
+  [[deprecated("ReadBlock has been renamed to ReadEvent")]]
+  bool ReadBlock(DelphesFactory *factory,
+    TObjArray *allParticleOutputArray,
+    TObjArray *stableParticleOutputArray,
+    TObjArray *partonOutputArray)
+  {
+    return ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray);
+  }
+
   void AnalyzeEvent(ExRootTreeBranch *branch, long long eventNumber,
     TStopwatch *readStopWatch, TStopwatch *procStopWatch);
 


### PR DESCRIPTION
Commit https://github.com/delphes/delphes/commit/93e1a6265184179895389125e7f91ddc18a19496 will break all downstream code using `ReadBlock` without warning. A better way is to deprecate first, wait some time (for example, to have at least one tag with the warning) so that people can adapt their code, and then remove it.