### PR TITLE
Fix reader Clear overload warnings

### DIFF
--- a/classes/DelphesHepMC2Reader.cc
+++ b/classes/DelphesHepMC2Reader.cc
@@ -111,7 +111,7 @@ void DelphesHepMC2Reader::SetInputFile(FILE *inputFile)
 
 //---------------------------------------------------------------------------
 
-void DelphesHepMC2Reader::Clear()
+void DelphesHepMC2Reader::Clear(Option_t * /*option*/)
 {
   fStateSize = 0;
   fState.clear();

--- a/classes/DelphesHepMC2Reader.h
+++ b/classes/DelphesHepMC2Reader.h
@@ -51,7 +51,7 @@ public:
 
   void SetInputFile(FILE *inputFile);
 
-  void Clear();
+  void Clear(Option_t *option = "") override;
   bool EventReady();
 
   bool ReadEvent(DelphesFactory *factory,

--- a/classes/DelphesHepMC3Reader.cc
+++ b/classes/DelphesHepMC3Reader.cc
@@ -110,7 +110,7 @@ void DelphesHepMC3Reader::SetInputFile(FILE *inputFile)
 
 //---------------------------------------------------------------------------
 
-void DelphesHepMC3Reader::Clear()
+void DelphesHepMC3Reader::Clear(Option_t * /*option*/)
 {
   fWeights.clear();
   fMomentumCoefficient = 1.0;

--- a/classes/DelphesHepMC3Reader.h
+++ b/classes/DelphesHepMC3Reader.h
@@ -53,7 +53,7 @@ public:
 
   void SetInputFile(FILE *inputFile);
 
-  void Clear();
+  void Clear(Option_t *option = "") override;
   bool EventReady();
 
   bool ReadEvent(DelphesFactory *factory,

--- a/classes/DelphesLHEFReader.cc
+++ b/classes/DelphesLHEFReader.cc
@@ -108,7 +108,7 @@ void DelphesLHEFReader::SetInputFile(FILE *inputFile)
 
 //---------------------------------------------------------------------------
 
-void DelphesLHEFReader::Clear()
+void DelphesLHEFReader::Clear(Option_t * /*option*/)
 {
   fEventReady = kFALSE;
   fEventCounter = -1;

--- a/classes/DelphesLHEFReader.h
+++ b/classes/DelphesLHEFReader.h
@@ -51,7 +51,7 @@ public:
 
   void SetInputFile(FILE *inputFile);
 
-  void Clear();
+  void Clear(Option_t *option = "") override;
   bool EventReady();
 
   void SkipEvent();

--- a/classes/DelphesPythia8Reader.cc
+++ b/classes/DelphesPythia8Reader.cc
@@ -124,7 +124,7 @@ string DelphesPythia8Reader::FileNameLHEF()
 
 //---------------------------------------------------------------------------
 
-void DelphesPythia8Reader::Clear()
+void DelphesPythia8Reader::Clear(Option_t * /*option*/)
 {
   fEventReady = kFALSE;
 }

--- a/classes/DelphesPythia8Reader.h
+++ b/classes/DelphesPythia8Reader.h
@@ -59,7 +59,7 @@ public:
   bool ReadLHEF();
   std::string FileNameLHEF();
 
-  void Clear();
+  void Clear(Option_t *option = "") override;
   bool EventReady();
 
   int EventNumber();

--- a/classes/DelphesSTDHEPReader.cc
+++ b/classes/DelphesSTDHEPReader.cc
@@ -110,7 +110,7 @@ void DelphesSTDHEPReader::SetInputFile(FILE *inputFile)
 
 //---------------------------------------------------------------------------
 
-void DelphesSTDHEPReader::Clear()
+void DelphesSTDHEPReader::Clear(Option_t * /*option*/)
 {
   fBlockType = -1;
 }

--- a/classes/DelphesSTDHEPReader.h
+++ b/classes/DelphesSTDHEPReader.h
@@ -64,7 +64,7 @@ public:
 
   void SetInputFile(FILE *inputFile);
 
-  void Clear();
+  void Clear(Option_t *option = "") override;
   bool EventReady();
 
   bool ReadEvent(DelphesFactory *factory,

--- a/modules/BTagging.cc
+++ b/modules/BTagging.cc
@@ -28,8 +28,6 @@
 
 #include "modules/BTagging.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -47,6 +45,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -83,7 +82,7 @@ void BTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
   }
 
   // set default efficiency formula
@@ -93,7 +92,7 @@ void BTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = std::move(formula);
+    fEfficiencyMap[0] = move(formula);
   }
 
   // import input array(s)

--- a/modules/BTagging.cc
+++ b/modules/BTagging.cc
@@ -28,6 +28,8 @@
 
 #include "modules/BTagging.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -81,7 +83,7 @@ void BTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
   }
 
   // set default efficiency formula
@@ -91,7 +93,7 @@ void BTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = move(formula);
+    fEfficiencyMap[0] = std::move(formula);
   }
 
   // import input array(s)

--- a/modules/BoostedTagging.cc
+++ b/modules/BoostedTagging.cc
@@ -28,6 +28,8 @@
 
 #include "modules/BoostedTagging.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -123,7 +125,7 @@ void BoostedTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
   }
 
   // set default efficiency formula
@@ -133,7 +135,7 @@ void BoostedTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = move(formula);
+    fEfficiencyMap[0] = std::move(formula);
   }
 
   // import input array(s)

--- a/modules/BoostedTagging.cc
+++ b/modules/BoostedTagging.cc
@@ -28,8 +28,6 @@
 
 #include "modules/BoostedTagging.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -47,6 +45,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -125,7 +124,7 @@ void BoostedTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
   }
 
   // set default efficiency formula
@@ -135,7 +134,7 @@ void BoostedTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = std::move(formula);
+    fEfficiencyMap[0] = move(formula);
   }
 
   // import input array(s)

--- a/modules/ConstituentFilter.cc
+++ b/modules/ConstituentFilter.cc
@@ -26,6 +26,8 @@
 
 #include "modules/ConstituentFilter.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -84,7 +86,7 @@ void ConstituentFilter::Init()
     array = ImportArray(param[i].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = array;
-    fJetList.push_back(move(entry));
+    fJetList.push_back(std::move(entry));
   }
 
   param = GetParam("ConstituentInputArray");
@@ -96,7 +98,7 @@ void ConstituentFilter::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fConstituentList.push_back(move(entry));
+    fConstituentList.push_back(std::move(entry));
   }
 }
 

--- a/modules/ConstituentFilter.cc
+++ b/modules/ConstituentFilter.cc
@@ -26,8 +26,6 @@
 
 #include "modules/ConstituentFilter.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -49,6 +47,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -86,7 +85,7 @@ void ConstituentFilter::Init()
     array = ImportArray(param[i].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = array;
-    fJetList.push_back(std::move(entry));
+    fJetList.push_back(move(entry));
   }
 
   param = GetParam("ConstituentInputArray");
@@ -98,7 +97,7 @@ void ConstituentFilter::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fConstituentList.push_back(std::move(entry));
+    fConstituentList.push_back(move(entry));
   }
 }
 

--- a/modules/FastJetFinder.cc
+++ b/modules/FastJetFinder.cc
@@ -26,8 +26,6 @@
 
 #include "modules/FastJetFinder.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -49,6 +47,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "fastjet/ClusterSequence.hh"
@@ -276,7 +275,7 @@ void FastJetFinder::Init()
       entry.estimator = make_unique<JetMedianBackgroundEstimator>(SelectorRapRange(etaMin, etaMax), *fDefinition, *fAreaDefinition);
       entry.etaMin = etaMin;
       entry.etaMax = etaMax;
-      fEstimators.push_back(std::move(entry));
+      fEstimators.push_back(move(entry));
     }
   }
 

--- a/modules/FastJetFinder.cc
+++ b/modules/FastJetFinder.cc
@@ -26,6 +26,8 @@
 
 #include "modules/FastJetFinder.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -274,7 +276,7 @@ void FastJetFinder::Init()
       entry.estimator = make_unique<JetMedianBackgroundEstimator>(SelectorRapRange(etaMin, etaMax), *fDefinition, *fAreaDefinition);
       entry.etaMin = etaMin;
       entry.etaMax = etaMax;
-      fEstimators.push_back(move(entry));
+      fEstimators.push_back(std::move(entry));
     }
   }
 

--- a/modules/IdentificationMap.cc
+++ b/modules/IdentificationMap.cc
@@ -27,8 +27,6 @@
 
 #include "modules/IdentificationMap.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -50,6 +48,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -84,7 +83,7 @@ void IdentificationMap::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 3 + 2].GetString());
     pdg = param[i * 3].GetInt();
-    fEfficiencyMap.insert(make_pair(pdg, make_pair(param[i * 3 + 1].GetInt(), std::move(formula))));
+    fEfficiencyMap.insert(make_pair(pdg, make_pair(param[i * 3 + 1].GetInt(), move(formula))));
   }
 
   // set default efficiency formula
@@ -94,7 +93,7 @@ void IdentificationMap::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("1.0");
 
-    fEfficiencyMap.insert(make_pair(0, make_pair(0, std::move(formula))));
+    fEfficiencyMap.insert(make_pair(0, make_pair(0, move(formula))));
   }
 
   // import input array

--- a/modules/IdentificationMap.cc
+++ b/modules/IdentificationMap.cc
@@ -27,6 +27,8 @@
 
 #include "modules/IdentificationMap.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -82,7 +84,7 @@ void IdentificationMap::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 3 + 2].GetString());
     pdg = param[i * 3].GetInt();
-    fEfficiencyMap.insert(make_pair(pdg, make_pair(param[i * 3 + 1].GetInt(), move(formula))));
+    fEfficiencyMap.insert(make_pair(pdg, make_pair(param[i * 3 + 1].GetInt(), std::move(formula))));
   }
 
   // set default efficiency formula
@@ -92,7 +94,7 @@ void IdentificationMap::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("1.0");
 
-    fEfficiencyMap.insert(make_pair(0, make_pair(0, move(formula))));
+    fEfficiencyMap.insert(make_pair(0, make_pair(0, std::move(formula))));
   }
 
   // import input array

--- a/modules/JetFakeParticle.cc
+++ b/modules/JetFakeParticle.cc
@@ -27,8 +27,6 @@
 
 #include "modules/JetFakeParticle.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -50,6 +48,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -91,7 +90,7 @@ void JetFakeParticle::Init()
       throw runtime_error("Jets can only fake into electrons, muons or photons. Other particles are not authorized.");
     }
 
-    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
   }
 
   // set default efficiency formula
@@ -101,7 +100,7 @@ void JetFakeParticle::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = std::move(formula);
+    fEfficiencyMap[0] = move(formula);
   }
 
   // import input array

--- a/modules/JetFakeParticle.cc
+++ b/modules/JetFakeParticle.cc
@@ -27,6 +27,8 @@
 
 #include "modules/JetFakeParticle.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -89,7 +91,7 @@ void JetFakeParticle::Init()
       throw runtime_error("Jets can only fake into electrons, muons or photons. Other particles are not authorized.");
     }
 
-    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
   }
 
   // set default efficiency formula
@@ -99,7 +101,7 @@ void JetFakeParticle::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = move(formula);
+    fEfficiencyMap[0] = std::move(formula);
   }
 
   // import input array

--- a/modules/Merger.cc
+++ b/modules/Merger.cc
@@ -27,8 +27,6 @@
 
 #include "modules/Merger.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -49,6 +47,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -83,7 +82,7 @@ void Merger::Init()
     array = ImportArray(param[i].GetString());
     iterator.reset(array->MakeIterator());
 
-    fInputList.push_back(std::move(iterator));
+    fInputList.push_back(move(iterator));
   }
 
   // create output arrays

--- a/modules/Merger.cc
+++ b/modules/Merger.cc
@@ -27,6 +27,8 @@
 
 #include "modules/Merger.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -81,7 +83,7 @@ void Merger::Init()
     array = ImportArray(param[i].GetString());
     iterator.reset(array->MakeIterator());
 
-    fInputList.push_back(move(iterator));
+    fInputList.push_back(std::move(iterator));
   }
 
   // create output arrays

--- a/modules/TauTagging.cc
+++ b/modules/TauTagging.cc
@@ -28,8 +28,6 @@
 
 #include "modules/TauTagging.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -47,6 +45,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -136,7 +135,7 @@ void TauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
   }
 
   // set default efficiency formula
@@ -146,7 +145,7 @@ void TauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = std::move(formula);
+    fEfficiencyMap[0] = move(formula);
   }
 
   // import input array(s)

--- a/modules/TauTagging.cc
+++ b/modules/TauTagging.cc
@@ -28,6 +28,8 @@
 
 #include "modules/TauTagging.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -134,7 +136,7 @@ void TauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
   }
 
   // set default efficiency formula
@@ -144,7 +146,7 @@ void TauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = move(formula);
+    fEfficiencyMap[0] = std::move(formula);
   }
 
   // import input array(s)

--- a/modules/TrackCountingTauTagging.cc
+++ b/modules/TrackCountingTauTagging.cc
@@ -15,8 +15,6 @@
 
 #include "modules/TrackCountingTauTagging.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -38,6 +36,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -144,7 +143,7 @@ void TrackCountingTauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
   }
 
   // set default efficiency formula
@@ -154,7 +153,7 @@ void TrackCountingTauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = std::move(formula);
+    fEfficiencyMap[0] = move(formula);
   }
 
   // import input array(s)

--- a/modules/TrackCountingTauTagging.cc
+++ b/modules/TrackCountingTauTagging.cc
@@ -15,6 +15,8 @@
 
 #include "modules/TrackCountingTauTagging.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -142,7 +144,7 @@ void TrackCountingTauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile(param[i * 2 + 1].GetString());
 
-    fEfficiencyMap[param[i * 2].GetInt()] = move(formula);
+    fEfficiencyMap[param[i * 2].GetInt()] = std::move(formula);
   }
 
   // set default efficiency formula
@@ -152,7 +154,7 @@ void TrackCountingTauTagging::Init()
     formula = make_unique<DelphesFormula>();
     formula->Compile("0.0");
 
-    fEfficiencyMap[0] = move(formula);
+    fEfficiencyMap[0] = std::move(formula);
   }
 
   // import input array(s)

--- a/modules/TrackPileUpSubtractor.cc
+++ b/modules/TrackPileUpSubtractor.cc
@@ -26,6 +26,8 @@
 
 #include "modules/TrackPileUpSubtractor.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -92,7 +94,7 @@ void TrackPileUpSubtractor::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fInputList.push_back(move(entry));
+    fInputList.push_back(std::move(entry));
   }
 }
 

--- a/modules/TrackPileUpSubtractor.cc
+++ b/modules/TrackPileUpSubtractor.cc
@@ -26,8 +26,6 @@
 
 #include "modules/TrackPileUpSubtractor.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -49,6 +47,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -94,7 +93,7 @@ void TrackPileUpSubtractor::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fInputList.push_back(std::move(entry));
+    fInputList.push_back(move(entry));
   }
 }
 

--- a/modules/UniqueObjectFinder.cc
+++ b/modules/UniqueObjectFinder.cc
@@ -26,6 +26,8 @@
 
 #include "modules/UniqueObjectFinder.h"
 
+#include <utility>
+
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -83,7 +85,7 @@ void UniqueObjectFinder::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fInputList.push_back(move(entry));
+    fInputList.push_back(std::move(entry));
   }
 }
 

--- a/modules/UniqueObjectFinder.cc
+++ b/modules/UniqueObjectFinder.cc
@@ -26,8 +26,6 @@
 
 #include "modules/UniqueObjectFinder.h"
 
-#include <utility>
-
 #include "classes/DelphesClasses.h"
 #include "classes/DelphesFactory.h"
 #include "classes/DelphesFormula.h"
@@ -48,6 +46,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 
 using namespace std;
 
@@ -85,7 +84,7 @@ void UniqueObjectFinder::Init()
     array = ImportArray(param[i * 2].GetString());
     entry.iterator.reset(array->MakeIterator());
     entry.array = ExportArray(param[i * 2 + 1].GetString());
-    fInputList.push_back(std::move(entry));
+    fInputList.push_back(move(entry));
   }
 }
 


### PR DESCRIPTION
## Summary

- Make the five reader `Clear` methods override `TObject::Clear(Option_t *)`.
- Include `<utility>` directly in module implementation files that call `move`.
- Do not modify vendored code.

## Clang diagnostics fixed by this PR

The following five project diagnostics came from reader `Clear()` overloads that hid `TObject::Clear(Option_t *)`. Each reader now uses the matching `Option_t *` signature and `override`.

```text
classes/DelphesHepMC2Reader.h:54:8: warning: 'DelphesHepMC2Reader::Clear' hides overloaded virtual function [-Woverloaded-virtual]
classes/DelphesHepMC3Reader.h:56:8: warning: 'DelphesHepMC3Reader::Clear' hides overloaded virtual function [-Woverloaded-virtual]
classes/DelphesLHEFReader.h:54:8: warning: 'DelphesLHEFReader::Clear' hides overloaded virtual function [-Woverloaded-virtual]
classes/DelphesPythia8Reader.h:62:8: warning: 'DelphesPythia8Reader::Clear' hides overloaded virtual function [-Woverloaded-virtual]
classes/DelphesSTDHEPReader.h:67:8: warning: 'DelphesSTDHEPReader::Clear' hides overloaded virtual function [-Woverloaded-virtual]
```

## Other Clang diagnostics observed

Clang also reports the following 18 `-Wunqualified-std-cast-call` diagnostics for unqualified `move` calls. They are intentionally left in the existing project style: the review requested that no `std::` prefixes be added to implementation files.

```text
modules/BTagging.cc:84:45: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/BTagging.cc:94:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/BoostedTagging.cc:126:45: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/BoostedTagging.cc:136:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/ConstituentFilter.cc:87:24: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/ConstituentFilter.cc:99:32: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/FastJetFinder.cc:277:29: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/IdentificationMap.cc:85:79: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/IdentificationMap.cc:95:53: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/JetFakeParticle.cc:102:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/JetFakeParticle.cc:92:45: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/Merger.cc:84:26: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/TauTagging.cc:137:45: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/TauTagging.cc:147:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/TrackCountingTauTagging.cc:145:45: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/TrackCountingTauTagging.cc:155:25: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/TrackPileUpSubtractor.cc:95:26: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
modules/UniqueObjectFinder.cc:86:26: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
```
